### PR TITLE
Force 32bit color in BMP, others are not yet fully supported

### DIFF
--- a/source/Img32.Fmt.BMP.pas
+++ b/source/Img32.Fmt.BMP.pas
@@ -782,6 +782,7 @@ begin
     else if palCnt > 2 then BitCount := 4
     else BitCount := 1;
   end;
+  BitCount := 32; // Other bit formats are not yet fully supported.
 
   if fIncludeFileHeaderInSaveStream then
   begin


### PR DESCRIPTION
Other than 32bit colors causes invalid images. We enforce 32bit until fully fixed.

I found cases of corrupted images that can not be properly loaded, and this also makes CopyToBitmap to crash.

IMHO, it's acceptable to save as 32bit. I keep most of the code for other bit formats as it seems almost there.
