### PR TITLE
Improve x86 Trunc/Round code

### DIFF
--- a/source/Img32.Draw.pas
+++ b/source/Img32.Draw.pas
@@ -306,6 +306,15 @@ type
 
 implementation
 
+{$IFDEF CPUX86}
+const
+  // Use faster Trunc/Round for x86 code in this unit.
+  Trunc: function(Value: Double): Integer = __Trunc;
+  {$IFDEF ASM_X86}
+  Round: function(Value: Double): Integer = __Round;
+  {$ENDIF ASM_X86}
+{$ENDIF CPUX86}
+
 type
 
   // A horizontal scanline contains any number of line fragments. A fragment

--- a/source/Img32.Transform.pas
+++ b/source/Img32.Transform.pas
@@ -117,6 +117,15 @@ uses Img32.Resamplers;
 resourcestring
   rsInvalidScale   = 'Invalid matrix scaling factor (0)';
 
+{$IFDEF CPUX86}
+const
+  // Use faster Trunc/Round for x86 code in this unit.
+  Trunc: function(Value: Double): Integer = __Trunc;
+  {$IFDEF ASM_X86}
+  Round: function(Value: Double): Integer = __Round;
+  {$ENDIF ASM_X86}
+{$ENDIF CPUX86}
+
 //------------------------------------------------------------------------------
 // Matrix functions
 //------------------------------------------------------------------------------

--- a/source/Img32.Vector.pas
+++ b/source/Img32.Vector.pas
@@ -478,6 +478,15 @@ resourcestring
 const
   BuffSize = 64;
 
+{$IFDEF CPUX86}
+const
+  // Use faster Trunc/Round for x86 code in this unit.
+  Trunc: function(Value: Double): Integer = __Trunc;
+  {$IFDEF ASM_X86}
+  Round: function(Value: Double): Integer = __Round;
+  {$ENDIF ASM_X86}
+{$ENDIF CPUX86}
+
 //------------------------------------------------------------------------------
 // TSizeD
 //------------------------------------------------------------------------------


### PR DESCRIPTION
The x86 FPU code is very slow when Trunc or Round is used. This patch adds the __Trunc method (that was already there in a previous version of Img32.pas) and adds a __Round function that, if the CPU supports SSE2 instructions, uses the SSE2 rounding code.

In order to not affect the 64 bit code, these two functions are mapped to Trunc and Round by using const function pointers only if "CPUX86" is defined. The Img32.pas probes the CPU via the CPUID instruction in the initialization block to detect SSE2 availability. If the library doesn't have to support older CPUs than Pentium 4/Athlon/Opteron, then the CPUID code could be removed.

The __Trunc function was formerly discussed in issue #45.