### PR TITLE
Improve x86 Trunc() performance

### DIFF
--- a/source/Img32.Draw.pas
+++ b/source/Img32.Draw.pas
@@ -306,6 +306,12 @@ type
 
 implementation
 
+{$IFDEF CPUX86}
+const
+  // Use faster Trunc for x86 code in this unit.
+  Trunc: function(Value: Double): Integer = __Trunc;
+{$ENDIF CPUX86}
+
 type
 
   // A horizontal scanline contains any number of line fragments. A fragment

--- a/source/Img32.Transform.pas
+++ b/source/Img32.Transform.pas
@@ -117,6 +117,12 @@ uses Img32.Resamplers;
 resourcestring
   rsInvalidScale   = 'Invalid matrix scaling factor (0)';
 
+{$IFDEF CPUX86}
+const
+  // Use faster Trunc for x86 code in this unit.
+  Trunc: function(Value: Double): Integer = __Trunc;
+{$ENDIF CPUX86}
+
 //------------------------------------------------------------------------------
 // Matrix functions
 //------------------------------------------------------------------------------

--- a/source/Img32.Vector.pas
+++ b/source/Img32.Vector.pas
@@ -478,6 +478,12 @@ resourcestring
 const
   BuffSize = 64;
 
+{$IFDEF CPUX86}
+const
+  // Use faster Trunc for x86 code in this unit.
+  Trunc: function(Value: Double): Integer = __Trunc;
+{$ENDIF CPUX86}
+
 //------------------------------------------------------------------------------
 // TSizeD
 //------------------------------------------------------------------------------

--- a/source/Img32.inc
+++ b/source/Img32.inc
@@ -50,10 +50,13 @@
 {$ELSE}
   {$IF COMPILERVERSION < 15}
     Your version of Delphi is not supported (Image32 requires Delphi version 7 or above)
-  {$IFEND}  
+  {$IFEND}
+  {$IFDEF CPU386}
+    {$DEFINE CPUX86}                            // CPUX86 was added in Delphi XE2
+  {$ENDIF}
   {$IFDEF CPUX86}
       {$DEFINE ASM_X86}                         //caution: do not define in FPC
-  {$ENDIF}  
+  {$ENDIF}
   {$IF COMPILERVERSION >= 17}                   //Delphi 2005
     {$IFNDEF DEBUG}
       {$DEFINE INLINE}                            //added inlining


### PR DESCRIPTION
The x86 FPU code is very slow when Trunc is used. This patch adds the "__Trunc" function (that was already there in a previous version of Img32.pas).

In order to not affect the 64 bit code, the Trunc function is mapped to __Trunc by using a const function pointer that is only declared if "CPUX86" is defined.

The __Trunc function was formerly discussed in issue #45.