### PR TITLE
Fix for "code tidy" commit

### DIFF
--- a/source/Img32.Transform.pas
+++ b/source/Img32.Transform.pas
@@ -120,7 +120,7 @@ resourcestring
   rsInvalidScale   = 'Invalid matrix scaling factor (0)';
 
 const
-  DivOneByXTableSize = SizeOf(Word);
+  DivOneByXTableSize = 65536;
 
 {$IFDEF CPUX86}
   // Use faster Trunc for x86 code in this unit.

--- a/source/Img32.pas
+++ b/source/Img32.pas
@@ -676,6 +676,7 @@ function __Trunc(Value: Double): Integer;
 var
   exp: integer;
   i64: UInt64 absolute Value;
+  valueBytes: array[0..7] of Byte absolute Value;
 begin
   //https://en.wikipedia.org/wiki/Double-precision_floating-point_format
   Result := 0;
@@ -688,7 +689,9 @@ begin
     Result := ((i64 and $1FFFFFFFFFFFFF) shl (exp - 52)) or (UInt64(1) shl exp)
   else
     Result := ((i64 and $1FFFFFFFFFFFFF) shr (52 - exp)) or (UInt64(1) shl exp);
-  if Value < 0 then Result := -Result;
+  // Check for the sign bit without loading Value into the FPU.
+  // The simple bit-test is faster.
+  if valueBytes[7] and $80 <> 0 then Result := -Result; // replaces FPU code: if Value < 0 then Result := -Result;
 end;
 //------------------------------------------------------------------------------
 


### PR DESCRIPTION
DivOneByXTableSize = SizeOf(Word) results in an array with 2 instead of 65536 elements. "array[Word]" means "array[0..65535]"

The last line in __Trunc applies the sign flag to "Result". The "if Value < 0" shouldn't be used here because it loads "Value" into the FPU what is slow and destroys the performance gain the function has. Instead a sign-bit test is used, so__Trunc can work without any FPU code. The original PR used the TDoubleDataRec record. The new code uses an array[0..7] of Byte, making the function "inline" compatible.