### PR TITLE
Extend transformation functions

### DIFF
--- a/source/Img32.Extra.pas
+++ b/source/Img32.Extra.pas
@@ -3,7 +3,7 @@ unit Img32.Extra;
 (*******************************************************************************
 * Author    :  Angus Johnson                                                   *
 * Version   :  4.4                                                             *
-* Date      :  11 May 2024                                                     *
+* Date      :  3 July 2024                                                     *
 * Website   :  http://www.angusj.com                                           *
 * Copyright :  Angus Johnson 2019-2024                                         *
 * Purpose   :  Miscellaneous routines that don't belong in other modules.      *
@@ -1221,7 +1221,11 @@ begin
       inc(s, w); inc(s2, w); inc(d, w);
     end;
   end;
-  Move(tmp2[0], img.PixelBase^, w * h * sizeOf(TColor32));
+
+  img.BlockNotify;
+  img.AssignPixelArray(tmp2, w, h);
+  img.UnblockNotify;
+
   if intensity < 1 then Exit;
   if intensity > 10 then
     intensity := 10; // range = 1-10

--- a/source/Img32.Layers.pas
+++ b/source/Img32.Layers.pas
@@ -3,7 +3,7 @@ unit Img32.Layers;
 (*******************************************************************************
 * Author    :  Angus Johnson                                                   *
 * Version   :  4.5                                                             *
-* Date      :  21 June 2024                                                    *
+* Date      :  3 July 2024                                                     *
 * Website   :  http://www.angusj.com                                           *
 * Copyright :  Angus Johnson 2019-2024                                         *
 * Purpose   :  Layered images support                                          *
@@ -1813,10 +1813,10 @@ begin
   begin
     Image.BeginUpdate;
     try
-      Image.Assign(MasterImage);
+      Image.AssignSettings(MasterImage);
       //apply any prior transformations
       Image.Resampler := rWeightedBilinear;
-      AffineTransformImage(Image, fMatrix, true); // assumes no skew
+      AffineTransformImage(MasterImage, Image, fMatrix, true); // assumes no skew
       //cropping is very important with rotation
       SymmetricCropTransparent(Image);
       w := Ceil(newBounds.Right) - Floor(newBounds.Left);
@@ -1861,12 +1861,12 @@ begin
 
   Image.BlockNotify;
   try
-    Image.Assign(MasterImage);
+    Image.AssignSettings(MasterImage);
     mat := fMatrix;
     pt := PointD(PivotPt.X - fLeft, PivotPt.Y - fTop);
     MatrixRotate(mat, pt, Angle);
     Image.Resampler := rWeightedBilinear;
-    AffineTransformImage(Image, mat, true); // assumes no skew
+    AffineTransformImage(MasterImage, Image, mat, true); // assumes no skew
   finally
     Image.UnblockNotify;
   end;

--- a/source/Img32.Resamplers.pas
+++ b/source/Img32.Resamplers.pas
@@ -3,7 +3,7 @@ unit Img32.Resamplers;
 (*******************************************************************************
 * Author    :  Angus Johnson                                                   *
 * Version   :  4.4                                                             *
-* Date      :  2 May 2024                                                      *
+* Date      :  3 July 2024                                                     *
 * Website   :  http://www.angusj.com                                           *
 * Copyright :  Angus Johnson 2019-2024                                         *
 * Purpose   :  For image transformations (scaling, rotating etc.)              *
@@ -26,6 +26,9 @@ uses
 procedure BoxDownSampling(Image: TImage32; scale: double); overload;
 procedure BoxDownSampling(Image: TImage32; scaleX, scaleY: double); overload;
 procedure BoxDownSampling(Image: TImage32; newWidth, newHeight: Integer); overload;
+procedure BoxDownSampling(Image, TargetImage: TImage32; scale: double); overload;
+procedure BoxDownSampling(Image, TargetImage: TImage32; scaleX, scaleY: double); overload;
+procedure BoxDownSampling(Image, TargetImage: TImage32; newWidth, newHeight: Integer); overload;
 
 // The following general purpose resamplers are registered below:
 // function NearestResampler(img: TImage32; x, y: double): TColor32;
@@ -579,21 +582,39 @@ end;
 
 procedure BoxDownSampling(Image: TImage32; scaleX, scaleY: double);
 begin
-  BoxDownSampling(Image,
-    Max(1, Integer(Round(Image.Width * scaleX))),
-    Max(1, Integer(Round(Image.Height * scaleY))));
+  BoxDownSampling(Image, Image, scaleX, scaleY);
 end;
 //------------------------------------------------------------------------------
 
 procedure BoxDownSampling(Image: TImage32; scale: double);
 begin
-  BoxDownSampling(Image,
+  BoxDownSampling(Image, Image, scale);
+end;
+//------------------------------------------------------------------------------
+
+procedure BoxDownSampling(Image: TImage32; newWidth, newHeight: Integer);
+begin
+  BoxDownSampling(Image, Image, newWidth, newHeight);
+end;
+//------------------------------------------------------------------------------
+
+procedure BoxDownSampling(Image, TargetImage: TImage32; scaleX, scaleY: double);
+begin
+  BoxDownSampling(Image, TargetImage,
+    Max(1, Integer(Round(Image.Width * scaleX))),
+    Max(1, Integer(Round(Image.Height * scaleY))));
+end;
+//------------------------------------------------------------------------------
+
+procedure BoxDownSampling(Image, TargetImage: TImage32; scale: double);
+begin
+  BoxDownSampling(Image, TargetImage,
     Max(1, Integer(Round(Image.Width * scale))),
     Max(1, Integer(Round(Image.Height * scale))));
 end;
 //------------------------------------------------------------------------------
 
-procedure BoxDownSampling(Image: TImage32; newWidth, newHeight: Integer);
+procedure BoxDownSampling(Image, TargetImage: TImage32; newWidth, newHeight: Integer);
 var
   x,y, x256,y256,xx256,yy256: Integer;
   sx,sy: double;
@@ -626,10 +647,7 @@ begin
     y256 := yy256;
   end;
 
-  Image.BeginUpdate;
-  Image.SetSize(newWidth, newHeight);
-  Move(tmp[0], Image.Pixels[0], newWidth * newHeight * SizeOf(TColor32));
-  Image.EndUpdate;
+  TargetImage.AssignPixelArray(tmp, newWidth, newHeight);
 end;
 //------------------------------------------------------------------------------
 //------------------------------------------------------------------------------

--- a/source/Img32.SVG.Reader.pas
+++ b/source/Img32.SVG.Reader.pas
@@ -947,6 +947,7 @@ end;
 procedure TImageElement.Draw(image: TImage32; drawDat: TDrawData);
 var
   dstRecD: TRectD;
+  tmp: TImage32;
 begin
   dstRecD := Self.elRectWH.GetRectD(0,0);
   drawDat.matrix := MatrixMultiply(drawDat.matrix, fDrawData.matrix);
@@ -960,7 +961,16 @@ begin
   end;
 
   if fImage <> nil then
-    image.Copy(fImage, fImage.Bounds, Rect(dstRecD));
+  begin
+    tmp := TImage32.Create();
+    try
+      tmp.AssignSettings(fImage);
+      MatrixApply(drawDat.matrix, fImage, tmp);
+      image.Copy(tmp, tmp.Bounds, Rect(dstRecD));
+    finally
+      tmp.Free;
+    end;
+  end;
 end;
 
 //------------------------------------------------------------------------------

--- a/source/Img32.pas
+++ b/source/Img32.pas
@@ -3,7 +3,7 @@ unit Img32;
 (*******************************************************************************
 * Author    :  Angus Johnson                                                   *
 * Version   :  4.5                                                             *
-* Date      :  30 June 2024                                                    *
+* Date      :  3 July 2024                                                     *
 * Website   :  http://www.angusj.com                                           *
 * Copyright :  Angus Johnson 2019-2024                                         *
 * Purpose   :  The core module of the Image32 library                          *
@@ -185,8 +185,8 @@ type
     function GetIsEmpty: Boolean;
     function GetPixelBase: PColor32;
     function GetPixelRow(row: Integer): PColor32;
-    procedure NearestNeighborResize(newWidth, newHeight: Integer);
-    procedure ResamplerResize(newWidth, newHeight: Integer);
+    procedure NearestNeighborResize(targetImg: TImage32; newWidth, newHeight: Integer);
+    procedure ResamplerResize(targetImg: TImage32; newWidth, newHeight: Integer);
     procedure RotateLeft90;
     procedure RotateRight90;
     procedure Rotate180;
@@ -207,6 +207,9 @@ type
     property   UpdateCount: integer read fUpdateCnt;
   public
     constructor Create(width: Integer = 0; height: Integer = 0); overload;
+    //Create(src:array, width, height): Uses the specified array for the pixels.
+    //  Uses src for the pixels without copying it.
+    constructor Create(const src: TArrayOfColor32; width: Integer; height: Integer); overload;
     constructor Create(src: TImage32); overload;
     constructor Create(src: TImage32; const srcRec: TRect); overload;
     destructor Destroy; override;
@@ -219,11 +222,16 @@ type
 
     procedure Assign(src: TImage32);
     procedure AssignTo(dst: TImage32);
+    procedure AssignSettings(src: TImage32);
+    //AssignPixelArray: Replaces the content and takes ownership of src.
+    //  Uses src for the pixels without copying it.
+    procedure AssignPixelArray(const src: TArrayOfColor32; width: Integer; height: Integer);
 
     //SetSize: Erases any current image, and fills with the specified color.
     procedure SetSize(newWidth, newHeight: Integer; color: TColor32 = 0);
     //Resize: is very similar to Scale()
     procedure Resize(newWidth, newHeight: Integer);
+    procedure ResizeTo(targetImg: TImage32; newWidth, newHeight: Integer);
     //ScaleToFit: The image will be scaled proportionally
     procedure ScaleToFit(width, height: integer);
     //ScaleToFitCentered: The new image will be scaled and also centred
@@ -231,6 +239,8 @@ type
     procedure ScaleToFitCentered(const rect: TRect); overload;
     procedure Scale(s: double); overload;
     procedure Scale(sx, sy: double); overload;
+    procedure ScaleTo(targetImg: TImage32; s: double); overload;
+    procedure ScaleTo(targetImg: TImage32; sx, sy: double); overload;
 
     function Copy(src: TImage32; srcRec, dstRec: TRect): Boolean;
     //CopyBlend: Copies part or all of another image (src) on top of the
@@ -592,6 +602,7 @@ uses
 
 resourcestring
   rsImageTooLarge = 'Image32 error: the image is too large.';
+  rsInvalidImageArrayData = 'Image32 error: the specified pixels array and the size does not match.';
 
 //------------------------------------------------------------------------------
 //------------------------------------------------------------------------------
@@ -1572,6 +1583,22 @@ begin
 end;
 //------------------------------------------------------------------------------
 
+constructor TImage32.Create(const src: TArrayOfColor32; width: Integer; height: Integer);
+begin
+  fAntiAliased := true;
+  fResampler := DefaultResampler;
+
+  width := Max(0, width);
+  height := Max(0, height);
+  if Length(src) <> width * height then
+    raise Exception.Create(rsInvalidImageArrayData);
+
+  fWidth := width;
+  fHeight := height;
+  fPixels := src;
+end;
+//------------------------------------------------------------------------------
+
 constructor TImage32.Create(src: TImage32);
 begin
   Assign(src);
@@ -1709,10 +1736,7 @@ begin
   if dst = self then Exit;
   dst.BeginUpdate;
   try
-    dst.fResampler := fResampler;
-    dst.fIsPremultiplied := fIsPremultiplied;
-    dst.fAntiAliased := fAntiAliased;
-    dst.ResetColorCount;
+    dst.AssignSettings(Self);
     try
       dst.SetSize(Width, Height);
       if (Width > 0) and (Height > 0) then
@@ -1723,6 +1747,48 @@ begin
   finally
     dst.EndUpdate;
   end;
+end;
+//------------------------------------------------------------------------------
+
+procedure TImage32.AssignSettings(src: TImage32);
+begin
+  if assigned(src) and (src <> Self) then
+  begin
+    BeginUpdate;
+    try
+      fResampler := src.fResampler;
+      fIsPremultiplied := src.fIsPremultiplied;
+      fAntiAliased := src.fAntiAliased;
+      ResetColorCount;
+    finally
+      EndUpdate;
+    end;
+  end;
+end;
+//------------------------------------------------------------------------------
+
+procedure TImage32.AssignPixelArray(const src: TArrayOfColor32; width: Integer; height: Integer);
+var
+  wasResized: Boolean;
+begin
+  width := Max(0, width);
+  height := Max(0, height);
+  if Length(src) <> width * height then
+    raise Exception.Create(rsInvalidImageArrayData);
+
+  wasResized := (fWidth <> width) or (fHeight <> height);
+
+  BeginUpdate;
+  try
+    fWidth := width;
+    fHeight := height;
+    fPixels := src;
+  finally
+    EndUpdate;
+  end;
+
+  if wasResized then
+    Resized;
 end;
 //------------------------------------------------------------------------------
 
@@ -2006,36 +2072,42 @@ end;
 
 procedure TImage32.Resize(newWidth, newHeight: Integer);
 begin
+  ResizeTo(Self, newWidth, newHeight);
+end;
+//------------------------------------------------------------------------------
 
+procedure TImage32.ResizeTo(targetImg: TImage32; newWidth, newHeight: Integer);
+begin
   if (newWidth <= 0) or (newHeight <= 0) then
   begin
-    SetSize(0, 0);
+    targetImg.SetSize(0, 0);
     Exit;
   end
   else if (newWidth = fwidth) and (newHeight = fheight) then
   begin
+    if targetImg <> Self then targetImg.Assign(Self);
     Exit
   end
   else if IsEmpty then
   begin
-    SetSize(newWidth, newHeight);
+    targetImg.SetSize(newWidth, newHeight);
     Exit;
   end;
 
-  BlockNotify;
+  targetImg.BlockNotify;
   try
-    if fResampler <= rNearestResampler then
-      NearestNeighborResize(newWidth, newHeight)
+    if targetImg.fResampler <= rNearestResampler then
+      NearestNeighborResize(targetImg, newWidth, newHeight)
     else
-      ResamplerResize(newWidth, newHeight);
+      ResamplerResize(targetImg, newWidth, newHeight);
   finally
-    UnblockNotify;
+    targetImg.UnblockNotify;
   end;
-  Resized;
+  targetImg.Resized;
 end;
 //------------------------------------------------------------------------------
 
-procedure TImage32.NearestNeighborResize(newWidth, newHeight: Integer);
+procedure TImage32.NearestNeighborResize(targetImg: TImage32; newWidth, newHeight: Integer);
 var
   x, y, srcY: Integer;
   scaledXi, scaledYi: TArrayOfInteger;
@@ -2045,8 +2117,12 @@ begin
   //this NearestNeighbor code is slightly more efficient than
   //the more general purpose one in Img32.Resamplers
 
-  if (newWidth = fWidth) and (newHeight = fHeight) then Exit;
-  SetLength(tmp, newWidth * newHeight * SizeOf(TColor32));
+  if (newWidth = fWidth) and (newHeight = fHeight) then
+  begin
+    if targetImg <> Self then targetImg.Assign(Self);
+    Exit;
+  end;
+  SetLength(tmp, newWidth * newHeight);
 
   //get scaled X & Y values once only (storing them in lookup arrays) ...
   SetLength(scaledXi, newWidth);
@@ -2067,19 +2143,17 @@ begin
     end;
   end;
 
-  fPixels := tmp;
-  fwidth := newWidth;
-  fheight := newHeight;
+  targetImg.AssignPixelArray(tmp, newWidth, newHeight);
 end;
 //------------------------------------------------------------------------------
 
-procedure TImage32.ResamplerResize(newWidth, newHeight: Integer);
+procedure TImage32.ResamplerResize(targetImg: TImage32; newWidth, newHeight: Integer);
 var
   mat: TMatrixD;
 begin
   mat := IdentityMatrix;
   MatrixScale(mat, newWidth/fWidth, newHeight/fHeight);
-  AffineTransformImage(self, mat);
+  AffineTransformImage(self, targetImg, mat);
 end;
 //------------------------------------------------------------------------------
 
@@ -2089,10 +2163,23 @@ begin
 end;
 //------------------------------------------------------------------------------
 
+procedure TImage32.ScaleTo(targetImg: TImage32; s: double);
+begin
+  ScaleTo(targetImg, s, s);
+end;
+//------------------------------------------------------------------------------
+
 procedure TImage32.Scale(sx, sy: double);
 begin
   if (sx > 0) and (sy > 0) then
-    ReSize(Round(width * sx), Round(height * sy));
+    Resize(Round(width * sx), Round(height * sy));
+end;
+//------------------------------------------------------------------------------
+
+procedure TImage32.ScaleTo(targetImg: TImage32; sx, sy: double);
+begin
+  if (sx > 0) and (sy > 0) then
+    ResizeTo(targetImg, Round(width * sx), Round(height * sy));
 end;
 //------------------------------------------------------------------------------
 
@@ -2507,11 +2594,13 @@ begin
 
   if (scaleX <> 1.0) or (scaleY <> 1.0) then
   begin
-    //scale source (tmp) to the destination then call CopyBlend() again ...
-    tmp := TImage32.Create(src, srcRecClipped);
+    //scale source (tmp) to the destination then call CopyBlend() again ...^
+    tmp := TImage32.Create;
     try
-      tmp.Scale(scaleX, scaleY);
-      result := CopyBlend(tmp, tmp.Bounds, dstRec, blendFunc);
+      tmp.AssignSettings(src);
+      src.ScaleTo(tmp, scaleX, scaleY);
+      ScaleRect(srcRecClipped, scaleX, scaleY);
+      result := CopyBlend(tmp, srcRecClipped, dstRec, blendFunc);
     finally
       tmp.Free;
     end;


### PR DESCRIPTION
This patch adds functionality to the transformation functions, that allow to write the transformed image to a target-image instead of doing an inplace transformation. This reduced the the need to copy "array of TColor32" around or creating helper images, copying the whole source image into them and then transforming them.

**Changes:**
- Added: Transform functions can transform to a target TImage32 instead of modifying the source.
- Added: TImage32.Create(array, width, height) and TImage32.AssignPixelArray that allow to set an already existing "array of TColor32" as the fPixels array. (The TImage32 becomes the owner of the array)
- Added: TImage32.AssignSettings that copies the settings without changing the fPixels/fWidth/fHeight values.
- Added: TImage32.ResizeTo/ScaleTo that have an additional targetImg: TImage32 parameter
- Fixed: useBoxDownsampler detection. An image that is flipped by a matrix was only scaled down.
- Fixed: SVG TImageElement ignored the transformation matrix