### PR TITLE
Fix for issue #72 Negative index on array pointer can be unsupported

### DIFF
--- a/source/Img32.Extra.pas
+++ b/source/Img32.Extra.pas
@@ -2047,7 +2047,8 @@ begin
 end;
 //------------------------------------------------------------------------------
 
-function Clamp(val, endVal: integer): integer; inline;
+function Clamp(val, endVal: integer): integer;
+  {$IFDEF INLINE} inline; {$ENDIF}
 begin
   if val < 0 then Result := 0
   else if val >= endVal then Result := endVal -1
@@ -2055,7 +2056,8 @@ begin
 end;
 //------------------------------------------------------------------------------
 
-function ModEx(val, endVal: integer): integer; inline;
+function ModEx(val, endVal: integer): integer;
+  {$IFDEF INLINE} inline; {$ENDIF}
 begin
   Result := val mod endVal;
   if Result < 0 then Result := endVal + Result;
@@ -2079,7 +2081,8 @@ begin
 end;
 //------------------------------------------------------------------------------
 
-procedure Append(var path: TPathD; const pt: TPointD); inline;
+procedure Append(var path: TPathD; const pt: TPointD);
+  {$IFDEF INLINE} inline; {$ENDIF}
 var
   len: integer;
 begin

--- a/source/Img32.inc
+++ b/source/Img32.inc
@@ -38,6 +38,7 @@
   {$DEFINE RECORD_METHODS}
   {$DEFINE PBYTE}
   {$DEFINE NEWPOSFUNC}
+  {$DEFINE SUPPORTS_POINTERMATH}
   {.$DEFINE UITYPES}
   {$DEFINE NESTED_TYPES}
   {$IFNDEF DEBUG}
@@ -74,6 +75,7 @@
           {$DEFINE CHARINSET}                     //added CharInSet function
           {$DEFINE EXIT_PARAM}                    //added Exit(value)
           {$DEFINE ALPHAFORMAT}                   //added TBitmap.AlphaFormat property
+          {$DEFINE SUPPORTS_POINTERMATH}          //added {$POINTERMATH ON/OFF}
           {$IF COMPILERVERSION >= 21}           //Delphi 2010
             {$DEFINE GESTURES}                    //added screen gesture support
             {$IF COMPILERVERSION >= 23}         //DelphiXE2


### PR DESCRIPTION
The issue #72 didn't cause any problem with FPC because the code used a ```NativeInt``` for the array index. But it wasn't clear that this is the workaround for the FPC oddity.
With this patch, the code that uses negative indices now uses PointerMath data types, if they are available (FPC, Delphi 2009 and newer) and only falls back to the static array pointers with disabled RangeChecks for Delphi 7-2007.

It also fixes the Delphi 7 compile errors in Img32.Extra.pas.