### PR TITLE
Fix hints/warnings

### DIFF
--- a/source/Clipper2/Clipper.Engine.pas
+++ b/source/Clipper2/Clipper.Engine.pas
@@ -1017,6 +1017,11 @@ begin
   GetMem(v, sizeof(TVertex) * totalVerts);
   vertexList.Add(v);
 
+  {$IF not defined(FPC) and (CompilerVersion <= 26.0)}
+  // Delphi 7-XE5 have a problem with "continue" and the
+  // code analysis, marking "ascending" as "not initialized"
+  ascending := False;
+  {$IFEND}
   for i := 0 to High(paths) do
   begin
     len := Length(paths[i]);

--- a/source/Clipper2/Clipper.Offset.pas
+++ b/source/Clipper2/Clipper.Offset.pas
@@ -236,9 +236,7 @@ end;
 constructor TGroup.Create(const pathsIn: TPaths64; jt: TJoinType; et: TEndType);
 var
   i, len: integer;
-  a: double;
   isJoined: boolean;
-  pb: PBoolean;
 begin
   Self.joinType := jt;
   Self.endType := et;
@@ -345,7 +343,6 @@ var
   i,j, len, steps: Integer;
   r, stepsPer360, arcTol: Double;
   absDelta: double;
-  isShrinking: Boolean;
   rec: TRect64;
   pt0: TPoint64;
 begin

--- a/source/Img32.Fmt.BMP.pas
+++ b/source/Img32.Fmt.BMP.pas
@@ -759,7 +759,6 @@ var
   UsesAlpha: Boolean;
   pals: TArrayOfColor32;
   tmp: TImage32;
-  writeValue: TTriColor32;
 begin
   //write everything except a BMP file header because some streams
   //(eg resource streams) don't need a file header

--- a/source/Img32.Layers.pas
+++ b/source/Img32.Layers.pas
@@ -1189,6 +1189,11 @@ begin
     img := fMergeImage;
   end;
 
+  {$IF not defined(FPC) and (CompilerVersion <= 26.0)}
+  // Delphi 7-XE5 have a problem with "continue" and the
+  // code analysis, marking "childImg" as "not initialized"
+  childImg := nil;
+  {$IFEND}
   //merge redraw all children
   for i := 0 to ChildCount -1 do
   begin

--- a/source/Img32.Panels.pas
+++ b/source/Img32.Panels.pas
@@ -774,7 +774,7 @@ var
   inDrawRegion: Boolean;
 begin
   rec := GetInnerClientRect;
-  inDrawRegion := PtInRect(rec, Types.Point(X,Y));
+  inDrawRegion := Windows.PtInRect(rec, Types.Point(X,Y));
   if inDrawRegion and
     not (fScrollbarHorz.MouseDown or fScrollbarVert.MouseDown) then
   begin


### PR DESCRIPTION
This pull request fixes hints and warnings for the Delphi compilers.

It also fixes a compile error in Img32.Panels where PtInRect became ambiguous between Img32.Vector and WinApi.Windows.

For two warnings in Delphi 7-XE5 there is now a $IF because they emit a "variable not initialized" warning that is bogus, but those Delphi versions have a bug in the flow analyses if there are "continue" statements.

Delpihi 7 still emits a lot more warnings, but they are all compiler bugs. There isn't even a "continue", "break", "exit", "try/finally" near and especially not between the variable assignment and the its usage. But with this pull request Delphi 2009 and newer are warning/hint-free.