### PR TITLE
Improve FastGaussianBlur performance

### DIFF
--- a/source/Img32.Extra.pas
+++ b/source/Img32.Extra.pas
@@ -2299,16 +2299,17 @@ begin
     begin
       if ri <= re then
       begin
-        val.Add(src[ri]); inc(ri);
-        val.Subtract(src[li]); inc(li);
+        val.AddSubtract(src[ri], src[li]);
+        inc(ri);
+        inc(li);
       end;
       dst[ti] := val.Color; inc(ti);
     end;
     while ti <= re do
     begin
       if ti > re then Break;
-      val.Add(clNone32);
-      val.Subtract(src[li]); inc(li);
+      val.AddNoneSubtract(src[li]);
+      inc(li);
       dst[ti] := val.Color;
       inc(ti);
     end;
@@ -2350,15 +2351,16 @@ begin
     begin
       if ri <= re then
       begin
-        val.Add(src[ri]); inc(ri, w);
-        val.Subtract(src[li]); inc(li, w);
+        val.AddSubtract(src[ri], src[li]);
+        inc(ri, w);
+        inc(li, w);
       end;
       dst[ti] := val.Color; inc(ti, w);
     end;
     while ti <= re do
     begin
-      val.Add(clNone32);
-      val.Subtract(src[li]); inc(li, w);
+      val.AddNoneSubtract(src[li]);
+      inc(li, w);
       dst[ti] := val.Color;
       inc(ti, w);
     end;

--- a/source/Img32.Extra.pas
+++ b/source/Img32.Extra.pas
@@ -2269,7 +2269,7 @@ procedure BoxBlurH(var src, dst: TArrayOfColor32; w,h, stdDev: integer);
 var
   i,j, ti, li, ri, re, ovr: integer;
   fv, val: TWeightedColor;
-  ce: TColor32;
+  lastColor: TColor32;
 begin
   ovr := Max(0, stdDev - w);
   for i := 0 to h -1 do
@@ -2278,7 +2278,7 @@ begin
     li := ti;
     ri := ti +stdDev;
     re := ti +w -1; // idx of last pixel in row
-    ce := src[re];  // color of last pixel in row
+    lastColor := src[re];  // color of last pixel in row
     fv.Reset(src[ti]);
     val.Reset(src[ti], stdDev +1);
     for j := 0 to stdDev -1 - ovr do
@@ -2287,7 +2287,7 @@ begin
     for j := 0 to stdDev do
     begin
       if ri > re then
-        val.Add(ce) else
+        val.Add(lastColor) else
         val.Add(src[ri]);
       inc(ri);
       val.Subtract(fv);
@@ -2295,23 +2295,30 @@ begin
         dst[ti] := val.Color;
       inc(ti);
     end;
-    for j := stdDev +1 to w - stdDev -1 do
+
+    // Skip "val.Color" calculation if both for-loops are skipped anyway
+    if (ti <= re) or (w > stdDev*2 + 1) then
     begin
-      if ri <= re then
+      lastColor := val.Color;
+      for j := stdDev +1 to w - stdDev -1 do
       begin
-        val.AddSubtract(src[ri], src[li]);
-        inc(ri);
-        inc(li);
+        if ri <= re then
+        begin
+          if val.AddSubtract(src[ri], src[li]) then
+            lastColor := val.Color;
+          inc(ri);
+          inc(li);
+        end;
+        dst[ti] := lastColor; inc(ti);
       end;
-      dst[ti] := val.Color; inc(ti);
-    end;
-    while ti <= re do
-    begin
-      if ti > re then Break;
-      val.AddNoneSubtract(src[li]);
-      inc(li);
-      dst[ti] := val.Color;
-      inc(ti);
+      while ti <= re do
+      begin
+        if val.AddNoneSubtract(src[li]) then
+          lastColor := val.Color;
+        inc(li);
+        dst[ti] := lastColor;
+        inc(ti);
+      end;
     end;
   end;
 end;
@@ -2321,7 +2328,7 @@ procedure BoxBlurV(var src, dst: TArrayOfColor32; w, h, stdDev: integer);
 var
   i,j, ti, li, ri, re, ovr: integer;
   fv, val: TWeightedColor;
-  ce: TColor32;
+  lastColor: TColor32;
 begin
   ovr := Max(0, stdDev - h);
   for i := 0 to w -1 do
@@ -2330,7 +2337,7 @@ begin
     li := ti;
     ri := ti + stdDev * w;
     re := ti +w *(h-1); // idx of last pixel in column
-    ce := src[re];      // color of last pixel in column
+    lastColor := src[re];      // color of last pixel in column
     fv.Reset(src[ti]);
     val.Reset(src[ti], stdDev +1);
     for j := 0 to stdDev -1 -ovr do
@@ -2339,7 +2346,7 @@ begin
     for j := 0 to stdDev do
     begin
       if ri > re then
-        val.Add(ce) else
+        val.Add(lastColor) else
         val.Add(src[ri]);
       inc(ri, w);
       val.Subtract(fv);
@@ -2347,22 +2354,30 @@ begin
         dst[ti] := val.Color;
       inc(ti, w);
     end;
-    for j := stdDev +1 to h - stdDev -1 do
+
+    // Skip "val.Color" calculation if both for-loops are skipped anyway
+    if (ti <= re) or (h > stdDev*2 + 1) then
     begin
-      if ri <= re then
+      lastColor := val.Color;
+      for j := stdDev +1 to h - stdDev -1 do
       begin
-        val.AddSubtract(src[ri], src[li]);
-        inc(ri, w);
-        inc(li, w);
+        if ri <= re then
+        begin
+          if val.AddSubtract(src[ri], src[li]) then
+            lastColor := val.Color;
+          inc(ri, w);
+          inc(li, w);
+        end;
+        dst[ti] := lastColor; inc(ti, w);
       end;
-      dst[ti] := val.Color; inc(ti, w);
-    end;
-    while ti <= re do
-    begin
-      val.AddNoneSubtract(src[li]);
-      inc(li, w);
-      dst[ti] := val.Color;
-      inc(ti, w);
+      while ti <= re do
+      begin
+        if val.AddNoneSubtract(src[li]) then
+          lastColor := val.Color;
+        inc(li, w);
+        dst[ti] := lastColor;
+        inc(ti, w);
+      end;
     end;
   end;
 end;

--- a/source/Img32.Transform.pas
+++ b/source/Img32.Transform.pas
@@ -114,8 +114,8 @@ type
     procedure Subtract(c: TColor32); overload; {$IFDEF INLINE} inline; {$ENDIF}
     procedure Subtract(const other: TWeightedColor); overload;
       {$IFDEF INLINE} inline; {$ENDIF}
-    procedure AddSubtract(addC, subC: TColor32);
-    procedure AddNoneSubtract(c: TColor32); {$IFDEF INLINE} inline; {$ENDIF}
+    function AddSubtract(addC, subC: TColor32): Boolean; {$IFDEF INLINE} inline; {$ENDIF}
+    function AddNoneSubtract(c: TColor32): Boolean; {$IFDEF INLINE} inline; {$ENDIF}
     procedure AddWeight(w: Integer); {$IFDEF INLINE} inline; {$ENDIF}
     property AddCount: Integer read fAddCount;
     property Color: TColor32 read GetColor;
@@ -1244,13 +1244,14 @@ begin
 end;
 //------------------------------------------------------------------------------
 
-procedure TWeightedColor.AddSubtract(addC, subC: TColor32);
+function TWeightedColor.AddSubtract(addC, subC: TColor32): Boolean;
 var
   a: Cardinal;
 begin
   // add+subtract => fAddCount stays the same
 
   // skip identical colors
+  Result := False;
   if addC = subC then Exit;
 
   a := Byte(addC shr 24);
@@ -1260,6 +1261,7 @@ begin
     inc(fColorTotB, (a * Byte(addC)));
     inc(fColorTotG, (a * Byte(addC shr 8)));
     inc(fColorTotR, (a * Byte(addC shr 16)));
+    Result := True;
   end;
 
   a := Byte(subC shr 24);
@@ -1269,21 +1271,28 @@ begin
     dec(fColorTotB, (a * Byte(subC)));
     dec(fColorTotG, (a * Byte(subC shr 8)));
     dec(fColorTotR, (a * Byte(subC shr 16)));
+    Result := True;
   end;
 end;
 //------------------------------------------------------------------------------
 
-procedure TWeightedColor.AddNoneSubtract(c: TColor32);
+function TWeightedColor.AddNoneSubtract(c: TColor32): Boolean;
 var
   a: Cardinal;
 begin
   // add+subtract => fAddCount stays the same
+
   a := Byte(c shr 24);
-  if a = 0 then Exit;
-  dec(fAlphaTot, a);
-  dec(fColorTotB, (a * Byte(c)));
-  dec(fColorTotG, (a * Byte(c shr 8)));
-  dec(fColorTotR, (a * Byte(c shr 16)));
+  if a > 0 then
+  begin
+    dec(fAlphaTot, a);
+    dec(fColorTotB, (a * Byte(c)));
+    dec(fColorTotG, (a * Byte(c shr 8)));
+    dec(fColorTotR, (a * Byte(c shr 16)));
+    Result := True;
+  end
+  else
+    Result := False;
 end;
 //------------------------------------------------------------------------------
 

--- a/source/Img32.Transform.pas
+++ b/source/Img32.Transform.pas
@@ -114,6 +114,8 @@ type
     procedure Subtract(c: TColor32); overload; {$IFDEF INLINE} inline; {$ENDIF}
     procedure Subtract(const other: TWeightedColor); overload;
       {$IFDEF INLINE} inline; {$ENDIF}
+    procedure AddSubtract(addC, subC: TColor32);
+    procedure AddNoneSubtract(c: TColor32); {$IFDEF INLINE} inline; {$ENDIF}
     procedure AddWeight(w: Integer); {$IFDEF INLINE} inline; {$ENDIF}
     property AddCount: Integer read fAddCount;
     property Color: TColor32 read GetColor;
@@ -132,7 +134,7 @@ resourcestring
   rsInvalidScale   = 'Invalid matrix scaling factor (0)';
 
 const
-  DivOneByXTableSize = 65536;
+  DivOneByXTableSize = 1024;
 
 {$IFDEF CPUX86}
   // Use faster Trunc for x86 code in this unit.
@@ -1137,10 +1139,9 @@ end;
 procedure TWeightedColor.Reset(c: TColor32; w: Integer);
 var
   a: Cardinal;
-  argb: TARGB absolute c;
 begin
   fAddCount := w;
-  a := w * argb.A;
+  a := w * Byte(c shr 24);
   if a = 0 then
   begin
     fAlphaTot := 0;
@@ -1150,9 +1151,9 @@ begin
   end else
   begin
     fAlphaTot := a;
-    fColorTotB := (a * argb.B);
-    fColorTotG := (a * argb.G);
-    fColorTotR := (a * argb.R);
+    fColorTotB := (a * Byte(c));
+    fColorTotG := (a * Byte(c shr 8));
+    fColorTotR := (a * Byte(c shr 16));
   end;
 end;
 //------------------------------------------------------------------------------
@@ -1240,6 +1241,49 @@ begin
   dec(fColorTotR, other.fColorTotR);
   dec(fColorTotG, other.fColorTotG);
   dec(fColorTotB, other.fColorTotB);
+end;
+//------------------------------------------------------------------------------
+
+procedure TWeightedColor.AddSubtract(addC, subC: TColor32);
+var
+  a: Cardinal;
+begin
+  // add+subtract => fAddCount stays the same
+
+  // skip identical colors
+  if addC = subC then Exit;
+
+  a := Byte(addC shr 24);
+  if a > 0 then
+  begin
+    inc(fAlphaTot, a);
+    inc(fColorTotB, (a * Byte(addC)));
+    inc(fColorTotG, (a * Byte(addC shr 8)));
+    inc(fColorTotR, (a * Byte(addC shr 16)));
+  end;
+
+  a := Byte(subC shr 24);
+  if a > 0 then
+  begin
+    dec(fAlphaTot, a);
+    dec(fColorTotB, (a * Byte(subC)));
+    dec(fColorTotG, (a * Byte(subC shr 8)));
+    dec(fColorTotR, (a * Byte(subC shr 16)));
+  end;
+end;
+//------------------------------------------------------------------------------
+
+procedure TWeightedColor.AddNoneSubtract(c: TColor32);
+var
+  a: Cardinal;
+begin
+  // add+subtract => fAddCount stays the same
+  a := Byte(c shr 24);
+  if a = 0 then Exit;
+  dec(fAlphaTot, a);
+  dec(fColorTotB, (a * Byte(c)));
+  dec(fColorTotG, (a * Byte(c shr 8)));
+  dec(fColorTotR, (a * Byte(c shr 16)));
 end;
 //------------------------------------------------------------------------------
 


### PR DESCRIPTION
This pull request improves the performance of FastGaussianBlur by skipping identical color weight calculations in BoxBlurH and BoxBlurV. It also reduces the DivOneByXTable memory usage from 512KB to 8KB.