### PR TITLE
Blend function optimizations

### DIFF
--- a/source/Img32.Draw.pas
+++ b/source/Img32.Draw.pas
@@ -2473,7 +2473,7 @@ begin
       cr.Free;
     end;
     ApplyClearType(tmpImg, color, backColor);
-    img.CopyBlend(tmpImg, tmpImg.Bounds, rec, BlendToAlpha);
+    img.CopyBlend(tmpImg, tmpImg.Bounds, rec, BlendToAlphaLine);
   finally
     tmpImg.Free;
   end;

--- a/source/Img32.Extra.pas
+++ b/source/Img32.Extra.pas
@@ -556,7 +556,7 @@ begin
     DrawPolygon(shadowImg, shadowPolys, fillRule, color);
     FastGaussianBlur(shadowImg, shadowImg.Bounds, blurSize, 1);
     if cutoutInsideShadow then EraseInsidePaths(shadowImg, polys, fillRule);
-    img.CopyBlend(shadowImg, shadowImg.Bounds, rec, BlendToAlpha);
+    img.CopyBlend(shadowImg, shadowImg.Bounds, rec, BlendToAlphaLine);
   finally
     shadowImg.Free;
   end;
@@ -592,7 +592,7 @@ begin
     DrawPolygon(glowImg, glowPolys, fillRule, color);
     FastGaussianBlur(glowImg, glowImg.Bounds, blurRadius, 2);
     glowImg.ScaleAlpha(4);
-    img.CopyBlend(glowImg, glowImg.Bounds, rec, BlendToAlpha);
+    img.CopyBlend(glowImg, glowImg.Bounds, rec, BlendToAlphaLine);
   finally
     glowImg.Free;
   end;
@@ -897,7 +897,7 @@ begin
     path := Ellipse(cutoutRec);
     radGrad.SetParameters(rect3, clBlack32, clNone32);
     DrawPolygon(mask, path, frNonZero, radGrad);
-    cutout.CopyBlend(mask, mask.Bounds, cutout.Bounds, BlendMask);
+    cutout.CopyBlend(mask, mask.Bounds, cutout.Bounds, BlendMaskLine);
     // now remove red from the cutout
     RemoveColor(cutout, clRed32);
     // finally replace the cutout ...
@@ -937,7 +937,7 @@ begin
   try
     p := TranslatePath(path, -outsideBounds.Left, -outsideBounds.top);
     DrawPolygon(mask, p, fillRule, clBlack32);
-    img.CopyBlend(mask, mask.Bounds, outsideBounds, BlendMask);
+    img.CopyBlend(mask, mask.Bounds, outsideBounds, BlendMaskLine);
   finally
     mask.Free;
   end;
@@ -957,7 +957,7 @@ begin
   try
     pp := TranslatePath(paths, -outsideBounds.Left, -outsideBounds.top);
     DrawPolygon(mask, pp, fillRule, clBlack32);
-    img.CopyBlend(mask, mask.Bounds, outsideBounds, BlendMask);
+    img.CopyBlend(mask, mask.Bounds, outsideBounds, BlendMaskLine);
   finally
     mask.Free;
   end;
@@ -1003,7 +1003,7 @@ begin
       EraseInsidePaths(tmp, paths2, fillRule);
       FastGaussianBlur(tmp, tmp.Bounds, Round(blurRadius), 0);
       EraseOutsidePaths(tmp, paths, fillRule, tmp.Bounds);
-      img.CopyBlend(tmp, tmp.Bounds, rec, BlendToAlpha);
+      img.CopyBlend(tmp, tmp.Bounds, rec, BlendToAlphaLine);
     end;
     if GetAlpha(colorDk) > 0 then
     begin
@@ -1012,7 +1012,7 @@ begin
       EraseInsidePaths(tmp, paths2, fillRule);
       FastGaussianBlur(tmp, tmp.Bounds, Round(blurRadius), 0);
       EraseOutsidePaths(tmp, paths, fillRule, tmp.Bounds);
-      img.CopyBlend(tmp, tmp.Bounds, rec, BlendToAlpha);
+      img.CopyBlend(tmp, tmp.Bounds, rec, BlendToAlphaLine);
     end;
   finally
     tmp.Free;

--- a/source/Img32.Layers.pas
+++ b/source/Img32.Layers.pas
@@ -1259,7 +1259,7 @@ begin
           TranslateRect(rec2,
             Floor(childLayer.fOuterMargin -childLayer.Left -fOuterMargin),
             Floor(childLayer.fOuterMargin -childLayer.Top -fOuterMargin));
-          childImg2.CopyBlend(fClipImage, rec, rec2, BlendMask);
+          childImg2.CopyBlend(fClipImage, rec, rec2, BlendMaskLine);
         end;
       end else
         childImg2 := childImg;

--- a/source/Img32.SVG.Reader.pas
+++ b/source/Img32.SVG.Reader.pas
@@ -1017,7 +1017,7 @@ begin
           EraseOutsidePaths(tmpImg, clipPaths, frNonZero, clipRec) else
           EraseOutsidePaths(tmpImg, clipPaths, fDrawData.fillRule, clipRec);
       end;
-      image.CopyBlend(tmpImg, clipRec, clipRec, BlendToAlpha);
+      image.CopyBlend(tmpImg, clipRec, clipRec, BlendToAlphaLine);
     finally
       tmpImg.Free;
     end;
@@ -1035,7 +1035,7 @@ begin
     try
       DrawChildren(tmpImg, drawDat);
       TMaskElement(maskEl).ApplyMask(tmpImg, drawDat);
-      image.CopyBlend(tmpImg, clipRec, clipRec, BlendToAlpha);
+      image.CopyBlend(tmpImg, clipRec, clipRec, BlendToAlphaLine);
     finally
       tmpImg.Free;
     end;
@@ -1234,7 +1234,7 @@ begin
   tmpImg := TImage32.Create(img.Width, img.Height);
   try
     DrawChildren(tmpImg, drawDat);
-    img.CopyBlend(tmpImg, maskRec, maskRec, BlendBlueChannel);
+    img.CopyBlend(tmpImg, maskRec, maskRec, BlendBlueChannelLine);
   finally
     tmpImg.Free;
   end;
@@ -1832,8 +1832,8 @@ begin
 
   srcImg2 := pfe.GetNamedImage(in2);
   srcRec2 := GetBounds(srcImg2);
-  dstImg2.CopyBlend(srcImg2, srcRec2, dstRec2, BlendToAlpha);
-  dstImg2.CopyBlend(srcImg,  srcRec,  dstRec2, BlendToAlpha);
+  dstImg2.CopyBlend(srcImg2, srcRec2, dstRec2, BlendToAlphaLine);
+  dstImg2.CopyBlend(srcImg,  srcRec,  dstRec2, BlendToAlphaLine);
   if dstImg = srcImg then
     dstImg.Copy(dstImg2, dstRec2, dstRec);
 end;
@@ -1942,24 +1942,24 @@ begin
     coIn:
       begin
         dstImg2.Copy(srcImg, srcRec, dstRec2);
-        dstImg2.CopyBlend(srcImg2,  srcRec2,  dstRec2, BlendMask);
+        dstImg2.CopyBlend(srcImg2,  srcRec2,  dstRec2, BlendMaskLine);
       end;
     coOut:
       begin
         dstImg2.Copy(srcImg, srcRec, dstRec2);
-        dstImg2.CopyBlend(srcImg2,  srcRec2,  dstRec2, BlendInvertedMask);
+        dstImg2.CopyBlend(srcImg2,  srcRec2,  dstRec2, BlendInvertedMaskLine);
       end;
     coAtop:
       begin
         dstImg2.Copy(srcImg2, srcRec2, dstRec2);
-        dstImg2.CopyBlend(srcImg,  srcRec,  dstRec2, BlendToAlpha);
-        dstImg2.CopyBlend(srcImg2,  srcRec2,  dstRec2, BlendMask);
+        dstImg2.CopyBlend(srcImg,  srcRec,  dstRec2, BlendToAlphaLine);
+        dstImg2.CopyBlend(srcImg2,  srcRec2,  dstRec2, BlendMaskLine);
       end;
     coXOR:
       begin
         dstImg2.Copy(srcImg2, srcRec2, dstRec2);
-        dstImg2.CopyBlend(srcImg, srcRec, dstRec2, BlendToAlpha);
-        dstImg2.CopyBlend(srcImg2,  srcRec2,  dstRec2, BlendInvertedMask);
+        dstImg2.CopyBlend(srcImg, srcRec, dstRec2, BlendToAlphaLine);
+        dstImg2.CopyBlend(srcImg2,  srcRec2,  dstRec2, BlendInvertedMaskLine);
       end;
     coArithmetic:
       begin
@@ -1968,8 +1968,8 @@ begin
       end;
     else     //coOver
       begin
-        dstImg2.CopyBlend(srcImg2, srcRec2, dstRec2, BlendToAlpha);
-        dstImg2.CopyBlend(srcImg,  srcRec,  dstRec2, BlendToAlpha);
+        dstImg2.CopyBlend(srcImg2, srcRec2, dstRec2, BlendToAlphaLine);
+        dstImg2.CopyBlend(srcImg,  srcRec,  dstRec2, BlendToAlphaLine);
       end;
   end;
   if (dstImg <> dstImg2) then
@@ -2075,7 +2075,7 @@ begin
   if stdDev > 0 then
     FastGaussianBlur(dstImg, dstRec,
       Ceil(stdDev *0.75 * ParentFilterEl.fScale) , 1);
-  dstImg.CopyBlend(dropShadImg, dropShadImg.Bounds, dstRec, BlendToAlpha);
+  dstImg.CopyBlend(dropShadImg, dropShadImg.Bounds, dstRec, BlendToAlphaLine);
 end;
 
 //------------------------------------------------------------------------------
@@ -2142,7 +2142,7 @@ begin
       begin
         if not GetSrcAndDst then Continue;
         if Assigned(tmpImg) then
-          tmpImg.CopyBlend(srcImg, srcRec, tmpImg.Bounds, BlendToAlpha)
+          tmpImg.CopyBlend(srcImg, srcRec, tmpImg.Bounds, BlendToAlphaLine)
         else if srcImg = pfe.fSrcImg then
           tmpImg := pfe.GetNamedImage(SourceImage)
         else
@@ -2396,7 +2396,7 @@ begin
     end;
 
   if usingTempImage and (img <> image) then
-    image.CopyBlend(img, clipRec2, clipRec2, BlendToAlpha);
+    image.CopyBlend(img, clipRec2, clipRec2, BlendToAlphaLine);
 
   //todo: enable "paint-order" to change filled/stroked/marker paint order
   if HasMarkers then DrawMarkers(img, drawDat);


### PR DESCRIPTION
This pull request increases the performance of the blend functions. The existing blend functions are changed from using "absolute" and TARGB to using bit manipulations that are faster because memory access is reduced. ("absolute" forces the parameter to be copied from the CPU register onto the stack).

Another optimization is the introduction of Blend*Line functions (only those that are used by the SVG reader are implemented). Those function have more information available and can optimize for special cases.