### PR TITLE
Some smaller performance optimization

### DIFF
--- a/source/Img32.Draw.pas
+++ b/source/Img32.Draw.pas
@@ -1926,11 +1926,13 @@ begin
           ellipsePt.X := (-qb -qs)/(2 * qa) else
           ellipsePt.X := (-qb +qs)/(2 * qa);
         ellipsePt.Y := m * ellipsePt.X + c;
-        dist := Hypot(pt.X - fFocusPt.X, pt.Y - fFocusPt.Y);
-        dist2 := Hypot(ellipsePt.X - fFocusPt.X, ellipsePt.Y - fFocusPt.Y);
+
+        // Use sqr'ed distances (Sqrt(a^2+b^2)/Sqrt(x^2+y^2) => Sqrt((a^2+b^2)/(x^2+y^2))
+        dist := Sqr(pt.X - fFocusPt.X) + Sqr(pt.Y - fFocusPt.Y);
+        dist2 := Sqr(ellipsePt.X - fFocusPt.X) + Sqr(ellipsePt.Y - fFocusPt.Y);
         if dist2 = 0 then
           q := 1 else
-          q := dist/ dist2;
+          q := Sqrt(dist/dist2);
       end else
         q := 1; //shouldn't happen :)
     end;

--- a/source/Img32.Draw.pas
+++ b/source/Img32.Draw.pas
@@ -313,10 +313,6 @@ const
 {$ENDIF CPUX86}
 
 type
-  {$IF not declared(NativeInt)}
-  NativeInt = Integer;
-  {$IFEND}
-
   {$IFDEF SUPPORTS_POINTERMATH}
   // Works for Delphi 2009 and newer. For FPC it is a requirement,
   // otherwise 32bit and 64bit code behave differently for negative

--- a/source/Img32.SVG.Path.pas
+++ b/source/Img32.SVG.Path.pas
@@ -56,6 +56,7 @@ type
     fCtrlPts  : TPathD;
     fExtend   : integer;
   protected
+    procedure Changed; {$IFDEF INLINE} inline; {$ENDIF}
     function GetFlattened: TPathD; virtual;
     procedure GetFlattenedInternal; virtual; abstract;
     procedure Scale(value: double); virtual;
@@ -410,14 +411,14 @@ begin
   begin
     fCtrlPts := ScalePath(fCtrlPts, value);
     fFirstPt := ScalePoint(fFirstPt, value);
+    Changed;
   end;
 end;
 //------------------------------------------------------------------------------
 
 function TSvgPathSeg.DescaleAndOffset(const pt: TPointD): TPointD;
 begin
-  Result := pt;
-  TranslatePoint(Result, -parent.PathOffset.X, -parent.PathOffset.Y);
+  Result := TranslatePoint(pt, -parent.PathOffset.X, -parent.PathOffset.Y);
   Result := ScalePoint(Result, 1/Owner.Scale);
 end;
 //------------------------------------------------------------------------------
@@ -433,12 +434,14 @@ procedure TSvgPathSeg.Offset(dx, dy: double);
 begin
   fFirstPt := TranslatePoint(fFirstPt, dx, dy);
   fCtrlPts := TranslatePath(fCtrlPts, dx, dy);
+  Changed;
 end;
 //------------------------------------------------------------------------------
 
 procedure TSvgPathSeg.SetCtrlPts(const pts: TPathD);
 begin
   fCtrlPts := pts;
+  Changed;
 end;
 //------------------------------------------------------------------------------
 
@@ -458,9 +461,17 @@ begin
 end;
 //------------------------------------------------------------------------------
 
+procedure TSvgPathSeg.Changed;
+begin
+  if fFlatPath <> nil then
+    fFlatPath := nil; // DynArrayClear
+end;
+//------------------------------------------------------------------------------
+
 function TSvgPathSeg.GetFlattened: TPathD;
 begin
-  GetFlattenedInternal;
+  if fFlatPath = nil then
+    GetFlattenedInternal;
   Result := fFlatPath;
 end;
 //------------------------------------------------------------------------------
@@ -502,9 +513,13 @@ begin
   //if the image has been rendered previously at a lower resolution, then
   //redo the flattening otherwise curves my look very rough.
   if (pendingScale < Parent.fPendingScale) then
+  begin
     pendingScale := Parent.fPendingScale;
+    Changed;
+  end;
 
-  GetFlattenedInternal;
+  if fFlatPath = nil then
+    GetFlattenedInternal;
   Result := fFlatPath;
 end;
 //------------------------------------------------------------------------------
@@ -567,6 +582,7 @@ begin
     end;
   end;
   SetCtrlPtsFromArcInfo;
+  Changed;
 end;
 //------------------------------------------------------------------------------
 
@@ -617,6 +633,7 @@ begin
     GetRectBtnPoints(fCtrlPts[1], fCtrlPts[2], fCtrlPts[3]);
     fCtrlPts[4] := endPos;
   end;
+  Changed;
 end;
 //------------------------------------------------------------------------------
 
@@ -660,12 +677,13 @@ end;
 procedure TSvgASegment.ReverseArc;
 begin
   fArcInfo.sweepClockW := not fArcInfo.sweepClockW;
+  Changed;
 end;
 //------------------------------------------------------------------------------
 
 procedure TSvgASegment.Offset(dx, dy: double);
 begin
-  inherited;
+  inherited; // calls Changed
   with fArcInfo do
   begin
     TranslateRect(rec, dx, dy);
@@ -678,7 +696,7 @@ end;
 procedure TSvgASegment.Scale(value: Double);
 begin
   if (value = 0) or (value = 1) then Exit;
-  inherited;
+  inherited; // calls Changed
   with fArcInfo do
   begin
     rec := ScaleRect(rec, value);
@@ -690,7 +708,7 @@ end;
 
 procedure TSvgASegment.SetCtrlPts(const ctrlPts: TPathD);
 begin
-  //SetCtrlPtsFromArcInfo;
+  //SetCtrlPtsFromArcInfo; // calls Changed
 end;
 //------------------------------------------------------------------------------
 
@@ -1073,13 +1091,17 @@ end;
 function TSvgSubPath.GetFlattenedPath(pendingScale: double): TPathD;
 var
   i: integer;
+  flattenedPaths: TPathsD;
 begin
   if pendingScale <= 0 then pendingScale := 1.0;
   if (pendingScale > fPendingScale) then
     fPendingScale := pendingScale;
+
   Result := nil;
+  SetLength(flattenedPaths, Length(fSegs));
   for i := 0 to High(fSegs) do
-    AppendPath(Result, fSegs[i].GetFlattened);
+    flattenedPaths[i] := fSegs[i].GetFlattened;
+  ConcatPaths(Result, flattenedPaths);
 end;
 //------------------------------------------------------------------------------
 
@@ -1102,6 +1124,7 @@ begin
   end;
   fSegs[i] := Result;
   Result.fCtrlPts := pts;
+  Result.fFlatPath := nil;
   if Result is TSvgCurvedSeg then
     TSvgCurvedSeg(Result).pendingScale := fPendingScale;
 end;
@@ -1125,7 +1148,7 @@ begin
     rectAngle := angle;
     sweepClockW := isClockwise;
   end;
-  Result.SetCtrlPtsFromArcInfo;
+  Result.SetCtrlPtsFromArcInfo; // calls Changed
 end;
 //------------------------------------------------------------------------------
 

--- a/source/Img32.SVG.Reader.pas
+++ b/source/Img32.SVG.Reader.pas
@@ -89,7 +89,7 @@ type
     //GetRelFracLimit: ie when to assume untyped vals are relative vals
     function  GetRelFracLimit: double; virtual;
     procedure Draw(image: TImage32; drawDat: TDrawData); virtual;
-    procedure DrawChildren(image: TImage32; drawDat: TDrawData); virtual;
+    procedure DrawChildren(image: TImage32; const drawDat: TDrawData);
   public
     constructor Create(parent: TBaseElement; svgEl: TSvgTreeEl); virtual;
     destructor  Destroy; override;
@@ -3723,7 +3723,7 @@ begin
 end;
 //------------------------------------------------------------------------------
 
-procedure TBaseElement.DrawChildren(image: TImage32; drawDat: TDrawData);
+procedure TBaseElement.DrawChildren(image: TImage32; const drawDat: TDrawData);
 var
   i: integer;
 begin

--- a/source/Img32.Transform.pas
+++ b/source/Img32.Transform.pas
@@ -520,15 +520,24 @@ end;
 function CanUseBoxDownsampler(const mat: TMatrixD; sx, sy: double): Boolean;
 begin
   // If the matrix looks like this after removing the scale,
-  // the box downsampler can be used.
+  // the box downsampler can be used. (only translation and scaling)
   //  cos(0)  -sin(0)  tx          1   0   tx
   //  sin(0)   cos(0)  ty    =>    0   1   ty
   //  0        0       1           0   0   1
 
+{
   Result := (mat[0,0]/sx = 1) and (mat[0,1]/sx = 0) and
             (mat[1,0]/sy = 0) and (mat[1,1]/sy = 1) and
             (mat[2,0]    = 0) and (mat[2,1]    = 0) and
             (mat[2,2]    = 1);
+}
+
+  // We can skip the divisions, because m/s is only zero if m is zero
+  // and m/s=1 is the same as m=s
+  Result := (SameValue(mat[0,0], sx)) and (mat[0,1] = 0) and
+            (mat[1,0] = 0)            and (SameValue(mat[1,1], sy)) and
+            (mat[2,0] = 0)            and (mat[2,1] = 0) and
+            (mat[2,2] = 1);
 end;
 {$ENDIF USE_DOWNSAMPLER_AUTOMATICALLY}
 

--- a/source/Img32.Vector.pas
+++ b/source/Img32.Vector.pas
@@ -220,6 +220,10 @@ type
   procedure AppendPath(var paths: TPathsD; const extra: TPathsD); overload;
   procedure AppendPath(var ppp: TArrayOfPathsD; const extra: TPathsD); overload;
 
+  // ConcatPaths concats multiple paths. It skips the start-point
+  // of a path, if it matches the previous path's end-point.
+  procedure ConcatPaths(var dstPath: TPathD; const paths: TPathsD);
+
   function GetAngle(const origin, pt: TPoint): double; overload;
   function GetAngle(const origin, pt: TPointD): double; overload;
   function GetAngle(const a, b, c: TPoint): double; overload;
@@ -1905,6 +1909,46 @@ begin
   if Assigned(extra) then
     AppendPath(ppp[len], extra) else
     ppp[len] := nil;
+end;
+//------------------------------------------------------------------------------
+
+procedure ConcatPaths(var dstPath: TPathD; const paths: TPathsD);
+var
+  i, len, pathLen, offset: integer;
+begin
+  // calculate the length of the final array
+  len := 0;
+  for i := 0 to high(paths) do
+  begin
+    pathLen := Length(paths[i]);
+    if pathLen > 0 then
+    begin
+      // Skip the start-point if is matches the previous path's end-point
+      if (i > 0) and PointsEqual(paths[i][0], paths[i -1][high(paths[i -1])]) then
+        dec(pathLen);
+      inc(len, pathLen);
+    end;
+  end;
+  SetLength(dstPath, len);
+
+  // fill the array
+  len := 0;
+  for i := 0 to high(paths) do
+  begin
+    pathLen := Length(paths[i]);
+    if pathLen > 0 then
+    begin
+      offset := 0;
+      // Skip the start-point if is matches the previous path's end-point
+      if (i > 0) and PointsEqual(paths[i][0], paths[i -1][high(paths[i -1])]) then
+      begin
+        dec(pathLen);
+        offset := 1;
+      end;
+      Move(paths[i][offset], dstPath[len], pathLen * SizeOf(TPointD));
+      inc(len, pathLen);
+    end;
+  end;
 end;
 //------------------------------------------------------------------------------
 

--- a/source/Img32.pas
+++ b/source/Img32.pas
@@ -1076,43 +1076,43 @@ begin
   // common values.
   while width < 0 do
   begin
-    a := PARGB(@PStaticColor32Array(bgColor)[width]).A;
+    a := PStaticARGBArray(bgColor)[width].A;
     // MulTable[0, fgA] -> 0 => replace color with 0
     while a = 0 do
     begin
       PStaticColor32Array(bgColor)[width] := 0;
       inc(width);
       if width = 0 then exit;
-      a := PARGB(@PStaticColor32Array(bgColor)[width]).A;
+      a := PStaticARGBArray(bgColor)[width].A;
     end;
     // MulTable[255, fgA] -> fgA => replace alpha with fgA
     while a = 255 do
     begin
-      PARGB(@PStaticColor32Array(bgColor)[width]).A := PARGB(@PStaticColor32Array(alphaMask)[width]).A;
+      PStaticARGBArray(bgColor)[width].A := PStaticARGBArray(alphaMask)[width].A;
       inc(width);
       if width = 0 then exit;
-      a := PARGB(@PStaticColor32Array(bgColor)[width]).A;
+      a := PStaticARGBArray(bgColor)[width].A;
     end;
 
-    a := PARGB(@PStaticColor32Array(alphaMask)[width]).A;
+    a := PStaticARGBArray(alphaMask)[width].A;
     // MulTable[bgA, 0] -> 0 => replace color with 0
     while a = 0 do
     begin
       PStaticColor32Array(bgColor)[width] := 0;
       inc(width);
       if width = 0 then exit;
-      a := PARGB(@PStaticColor32Array(alphaMask)[width]).A;
+      a := PStaticARGBArray(alphaMask)[width].A;
     end;
     // MulTable[bgA, 255] -> bgA => nothing to do
     while a = 255 do
     begin
       inc(width);
       if width = 0 then exit;
-      a := PARGB(@PStaticColor32Array(alphaMask)[width]).A;
+      a := PStaticARGBArray(alphaMask)[width].A;
     end;
 
-    a := MulTable[PARGB(@PStaticColor32Array(bgColor)[width]).A, a];
-    if a <> 0 then PARGB(@PStaticColor32Array(bgColor)[width]).A := a
+    a := MulTable[PStaticARGBArray(bgColor)[width].A, a];
+    if a <> 0 then PStaticARGBArray(bgColor)[width].A := a
     else PStaticColor32Array(bgColor)[width] := 0;
 
     inc(width);
@@ -1135,10 +1135,10 @@ begin
 
   while w < 0 do
   begin
-    a := MulTable[PARGB(@PStaticColor32Array(bgColor)[w]).A,
-                  PARGB(@PStaticColor32Array(alphaMask)[w]).A];
+    a := MulTable[PStaticARGBArray(bgColor)[w].A,
+                  PStaticARGBArray(alphaMask)[w].A];
     if a = 0 then PStaticColor32Array(bgColor)[w] := 0
-    else PARGB(@PStaticColor32Array(bgColor)[w]).A := a;
+    else PStaticARGBArray(bgColor)[w].A := a;
 
     inc(w);
   end;
@@ -1274,10 +1274,10 @@ begin
 
   while width < 0 do
   begin
-    a := MulTable[PARGB(@PStaticColor32Array(bgColor)[width]).A,
-                  PARGB(@PStaticColor32Array(alphaMask)[width]).A xor 255];
+    a := MulTable[PStaticARGBArray(bgColor)[width].A,
+                  PStaticARGBArray(alphaMask)[width].A xor 255];
     if a < 2 then PStaticColor32Array(bgColor)[width] := 0
-    else PARGB(@PStaticColor32Array(bgColor)[width]).A := a;
+    else PStaticARGBArray(bgColor)[width].A := a;
 
     inc(width);
   end;


### PR DESCRIPTION
This PR makes some smaller performance optimizations.

- Removes one (hidden) Sqrt() call in TSvgRadialGradientRenderer
- Optimizes TImage32.FillRect by using FillChar if possible
- Makes TBaseElement.DrawChildren() non-virtual and adds a "const" for the TDrawData parameter (no copy on the stack is created for TDrawData)
- Improves CanUseBoxDownsampler (remove of divisions)
- Improves the speed of RectHasTransparency if it is called for a full-width check
- Replaces `PARGB(@PStaticColor32Array(c)[i])` with `PStaticARGBArray(c)[i]` what allows Delphi to remove an unnecessary Load Effective Address (LEA) instruction
- Changes array index datatypes to NativeInt, allowing the x64 compiler to remove the sign-extension instruction before array accesses.
- Improves CopyInternal/CopyInternalLine performance by handling the case where a single Move() or BlendLineFunc() call can be used.
- Adds a ConcatPaths() function that doesn't need to reallocate the resulting array for every appended TPathD
- Improves the path flattening by caching the flattend paths and recreating them only if necessary
- Fixes a bug in TSvgPathSeg.DescaleAndOffset which ignored the result of TranslatePoint

