### PR TITLE
Dynamic array performance - skip unnecessary SetLength-FillChar

### DIFF
--- a/source/Img32.Draw.pas
+++ b/source/Img32.Draw.pas
@@ -1686,7 +1686,7 @@ begin
     fColorsCnt := Ceil(dy + dxdy * (fEndPt.X - fStartPt.X));
     MakeColorGradient(fGradientColors, fColorsCnt, fColors);
     // get a list of perpendicular offsets for each
-    SetLength(fPerpendicOffsets, ImgWidth);
+    NewIntegerArray(fPerpendicOffsets, ImgWidth, True);
     // from an imaginary line that's through fStartPt and perpendicular to
     // the gradient line, get a list of Y offsets for each X in image width
     for i := 0 to ImgWidth -1 do
@@ -1711,7 +1711,7 @@ begin
 
     fColorsCnt := Ceil(dx + dydx * (fEndPt.Y - fStartPt.Y));
     MakeColorGradient(fGradientColors, fColorsCnt, fColors);
-    SetLength(fPerpendicOffsets, ImgHeight);
+    NewIntegerArray(fPerpendicOffsets, ImgHeight, True);
     // from an imaginary line that's through fStartPt and perpendicular to
     // the gradient line, get a list of X offsets for each Y in image height
     for i := 0 to ImgHeight -1 do
@@ -2107,7 +2107,7 @@ var
   lines: TPathsD;
 begin
   setLength(lines, 1);
-  setLength(lines[0], 2);
+  NewPointDArray(lines[0], 2, True);
   lines[0][0] := pt1;
   lines[0][1] := pt2;
   DrawLine(img, lines, lineWidth, color, esRound);

--- a/source/Img32.Extra.pas
+++ b/source/Img32.Extra.pas
@@ -2095,7 +2095,7 @@ var
   len: integer;
 begin
   len := Length(path);
-  SetLength(path, len +1);
+  SetLengthUninit(path, len +1);
   path[len] := pt;
 end;
 //------------------------------------------------------------------------------

--- a/source/Img32.Extra.pas
+++ b/source/Img32.Extra.pas
@@ -678,7 +678,7 @@ var
 begin
   img.Clear(fillColor);
   w := img.Width; h := img.Height;
-  SetLength(path, 2);
+  NewPointDArray(path, 2, True);
   if minorInterval > 0 then
   begin
     x := minorInterval;
@@ -1091,7 +1091,7 @@ begin
   case buttonShape of
     bsDiamond:
       begin
-        SetLength(Result, 4);
+        NewPointDArray(Result, 4, True);
         for i := 0 to 3 do Result[i] := pt;
         Result[0].X := Result[0].X -radius;
         Result[1].Y := Result[1].Y -radius;
@@ -1754,7 +1754,7 @@ begin
   end;
   if highI +1 < minLen then Exit;
   if not isClosedPath then first := @srArray[0];
-  SetLength(Result, highI +1);
+  NewPointDArray(Result, highI +1, True);
   for i := 0 to HighI do
   begin
     Result[i] := first.pt;
@@ -1877,7 +1877,7 @@ begin
   end;
 
   if highI < 2 then Exit;
-  SetLength(Result, highI +1);
+  NewPointDArray(Result, highI +1, True);
   for i := 0 to HighI do
   begin
     Result[i] := current.pt;
@@ -1925,7 +1925,7 @@ begin
   len := Length(path);
   if len < 3 then Exit;
 
-  SetLength(Result, len *3 +1);
+  NewPointDArray(Result, len *3 +1, True);
   prev := len-1;
   SetLength(pl, len);
   SetLength(unitVecs, len);
@@ -1998,7 +1998,7 @@ begin
   len := Length(path);
   if len < 3 then Exit;
 
-  SetLength(Result, len *3 +1);
+  NewPointDArray(Result, len *3 +1);
   prev := len-1;
   SetLength(pl, len);
   SetLength(unitVecs, len);
@@ -2243,7 +2243,7 @@ var
   i, wl, wu, m: integer;
   wIdeal, mIdeal: double;
 begin
-  SetLength(Result, boxCnt);
+  NewIntegerArray(Result, boxCnt, True);
   wIdeal := Sqrt((12*stdDev*stdDev/boxCnt)+1); // Ideal averaging filter width
   wl := Floor(wIdeal); if not Odd(wl) then dec(wl);
   mIdeal :=

--- a/source/Img32.Extra.pas
+++ b/source/Img32.Extra.pas
@@ -1202,8 +1202,8 @@ var
 begin
   w := img.Width; h := img.Height;
   if w * h = 0 then Exit;
-  SetLength(tmp, w * h);
-  SetLength(tmp2, w * h);
+  NewColor32Array(tmp, w * h);
+  NewColor32Array(tmp2, w * h);
   s := img.PixelRow[0]; d := @tmp[0];
   for j := 0 to h-1 do
   begin
@@ -2401,8 +2401,8 @@ begin
   RectWidthHeight(rec2, w, h);
   if (Min(w, h) < 2) or ((stdDevX < 1) and (stdDevY < 1)) then Exit;
   len := w * h;
-  SetLength(src, len);
-  SetLength(dst, len);
+  NewColor32Array(src, len, True); // content is overwritten in BoxBlurH
+  NewColor32Array(dst, len, True);
   if blurFullImage then
   begin
     // copy the entire image into 'dst'

--- a/source/Img32.Fmt.QOI.pas
+++ b/source/Img32.Fmt.QOI.pas
@@ -132,7 +132,7 @@ begin
     inc(src, stream.Position);
   end else
   begin
-    SetLength(srcTmp, size);
+    NewByteArray(srcTmp, size, True);
     stream.Read(srcTmp[0], size);
     src := @srcTmp[0];
   end;

--- a/source/Img32.Layers.pas
+++ b/source/Img32.Layers.pas
@@ -2377,7 +2377,7 @@ var
   mp: TPointD;
 begin
   mp := MidPoint(rec);
-  SetLength(Result, 4);
+  NewPointDArray(Result, 4, True);
   Result[0] := PointD(mp.X, rec.Top);
   Result[1] := PointD(rec.Right, mp.Y);
   Result[2] := PointD(mp.X, rec.Bottom);
@@ -2462,7 +2462,7 @@ begin
   group := TSizingGroupLayer32(movedButton.Parent);
   with group do
   begin
-    SetLength(path, ChildCount);
+    NewPointDArray(path, ChildCount, True);
     for i := 0 to ChildCount -1 do
       path[i] := Child[i].MidPoint;
   end;

--- a/source/Img32.Resamplers.pas
+++ b/source/Img32.Resamplers.pas
@@ -741,13 +741,13 @@ var
   sx,sy: double;
   tmp: TArrayOfColor32;
   pc: PColor32;
-  scaledX: array of Integer;
+  scaledX: TArrayOfInteger;
 begin
   sx := Image.Width/newWidth * 256;
   sy := Image.Height/newHeight * 256;
   NewColor32Array(tmp, newWidth * newHeight, True);
 
-  SetLength(scaledX, newWidth +1); //+1 for fractional overrun
+  NewIntegerArray(scaledX, newWidth, True);
   for x := 0 to newWidth -1 do
     scaledX[x] := Round((x+1) * sx);
 
@@ -797,10 +797,10 @@ begin
   NewColor32Array(tmp, newWidth * newHeight, True);
 
   //get scaled X & Y values once only (storing them in lookup arrays) ...
-  SetLength(scaledXi, newWidth);
+  NewIntegerArray(scaledXi, newWidth, True);
   for x := 0 to newWidth -1 do
     scaledXi[x] := Trunc(x * Image.Width / newWidth);
-  SetLength(scaledYi, newHeight);
+  NewIntegerArray(scaledYi, newHeight, True);
   for y := 0 to newHeight -1 do
     scaledYi[y] := Trunc(y * Image.Height / newHeight);
 

--- a/source/Img32.Resamplers.pas
+++ b/source/Img32.Resamplers.pas
@@ -745,7 +745,7 @@ var
 begin
   sx := Image.Width/newWidth * 256;
   sy := Image.Height/newHeight * 256;
-  SetLength(tmp, newWidth * newHeight);
+  NewColor32Array(tmp, newWidth * newHeight, True);
 
   SetLength(scaledX, newWidth +1); //+1 for fractional overrun
   for x := 0 to newWidth -1 do
@@ -794,7 +794,7 @@ begin
     if TargetImage <> Image then TargetImage.Assign(Image);
     Exit;
   end;
-  SetLength(tmp, newWidth * newHeight);
+  NewColor32Array(tmp, newWidth * newHeight, True);
 
   //get scaled X & Y values once only (storing them in lookup arrays) ...
   SetLength(scaledXi, newWidth);

--- a/source/Img32.SVG.Path.pas
+++ b/source/Img32.SVG.Path.pas
@@ -626,7 +626,7 @@ end;
 
 procedure TSvgASegment.SetCtrlPtsFromArcInfo;
 begin
-  SetLength(fCtrlPts, 5);
+  NewPointDArray(fCtrlPts, 5, True);
   with fArcInfo do
   begin
     fCtrlPts[0] := startPos;
@@ -771,7 +771,7 @@ var
   i, len: integer;
 begin
   len := Length(fCtrlPts) div 3;
-  SetLength(Result, len);
+  NewPointDArray(Result, len, True);
   for i := 0 to High(Result) do
     Result[i] := fCtrlPts[i*3 +2];
 end;
@@ -890,7 +890,7 @@ var
   i, len: integer;
 begin
   len := Length(fCtrlPts) div 2;
-  SetLength(Result, len);
+  NewPointDArray(Result, len, True);
   for i := 0 to High(Result) do
     Result[i] := fCtrlPts[i*2+1];
 end;
@@ -955,7 +955,7 @@ var
   i, len: integer;
 begin
   len := Length(fCtrlPts) div 2;
-  SetLength(Result, len);
+  NewPointDArray(Result, len, True);
   for i := 0 to High(Result) do
     Result[i] := fCtrlPts[i*2+1];
 end;
@@ -1202,7 +1202,7 @@ begin
   SetLength(fSegs, i+1);
   Result := TSvgZSegment.Create(self, i, endPt);
   fSegs[i] := Result;
-  SetLength(Result.fCtrlPts, 1);
+  NewPointDArray(Result.fCtrlPts, 1, True);
   Result.fCtrlPts[0] := firstPt;
   isClosed := true;
 end;

--- a/source/Img32.SVG.Path.pas
+++ b/source/Img32.SVG.Path.pas
@@ -1236,7 +1236,7 @@ function TSvgSubPath.GetSimplePath: TPathD;
 var
   i: integer;
 begin
-  Result := Img32.Vector.MakePath([GetFirstPt.X, GetFirstPt.Y]);
+  Result := Img32.Vector.MakePath(GetFirstPt);
   for i := 0 to High(fSegs) do
     AppendPath(Result, fSegs[i].GetOnPathCtrlPts);
 end;
@@ -1413,7 +1413,7 @@ var
     if ptCnt = ptCap then
     begin
       inc(ptCap, 8);
-      setLength(pts, ptCap);
+      SetLengthUninit(pts, ptCap);
     end;
     pts[ptCnt] := pt;
     inc(ptCnt);

--- a/source/Img32.SVG.Reader.pas
+++ b/source/Img32.SVG.Reader.pas
@@ -845,7 +845,7 @@ begin
     for i := 0 to len -1 do
     begin
       len2 := Length(paths[i]);
-      SetLength(Result[i], len2);
+      NewPointDArray(Result[i], len2, True);
       if len2 = 0 then Continue;
       pp := @paths[i][0];
       rr := @Result[i][0];
@@ -2804,7 +2804,7 @@ end;
 constructor TLineElement.Create(parent: TBaseElement; svgEl: TSvgTreeEl);
 begin
   inherited;
-  SetLength(path, 2);
+  NewPointDArray(path, 2, True);
   path[0] := NullPointD; path[1] := NullPointD;
 end;
 //------------------------------------------------------------------------------
@@ -3502,7 +3502,7 @@ end;
 
 procedure TMarkerElement.SetEndPoint(const pt: TPointD; angle: double);
 begin
-  SetLength(fPoints, 1);
+  NewPointDArray(fPoints, 1, True);
   fPoints[0] := pt;
   self.angle := angle;
 end;

--- a/source/Img32.Transform.pas
+++ b/source/Img32.Transform.pas
@@ -631,7 +631,7 @@ begin
     Exit;
   end;
 
-  SetLength(tmp, newWidth * newHeight);
+  NewColor32Array(tmp, newWidth * newHeight, True);
   pc := @tmp[0];
   xLimLo := -0.5/sx;
   xLimHi := img.Width + 0.5/sx;
@@ -816,7 +816,7 @@ begin
 
   mat := GetProjectionMatrix(srcPts, dstPts2);
   RectWidthHeight(rec, w, h);
-  SetLength(tmp, w * h);
+  NewColor32Array(tmp, w * h, True);
   pc := @tmp[0];
   for i :=  0 to h -1 do
     for j := 0 to w -1 do
@@ -997,7 +997,7 @@ begin
   len := Length(topPath);
   inc(rec.Bottom, img.Height);
   RectWidthHeight(rec, w, h);
-  SetLength(tmp, (w+1) * h);
+  NewColor32Array(tmp, (w+1) * h, True);
 
   prevX := topPath[0].X;
   allowBackColoring := GetAlpha(backColor) > 2;
@@ -1082,7 +1082,7 @@ begin
   len := Length(leftPath);
   inc(rec.Right, img.Width);
   RectWidthHeight(rec, w, h);
-  SetLength(tmp, w * (h+1));
+  NewColor32Array(tmp, w * (h+1), True);
 
   prevY := leftPath[0].Y;
   allowBackColoring := GetAlpha(backColor) > 2;

--- a/source/Img32.Transform.pas
+++ b/source/Img32.Transform.pas
@@ -860,7 +860,7 @@ begin
     if x1 = x2 then Exit;
     dydx := (pt2.Y - pt1.Y)/(pt2.X - pt1.X);
     xo := x1 -pt1.X;
-    SetLength(Result, x2-x1);
+    NewPointDArray(Result, x2-x1, True);
     for i:= 0 to x2 - x1 -1 do
     begin
       Result[i].X := x1 +i;
@@ -873,7 +873,7 @@ begin
     if x1 = x2 then Exit;
     dydx := (pt2.Y - pt1.Y)/(pt2.X - pt1.X);
     xo := x1 -pt1.X;
-    SetLength(Result, x1-x2);
+    NewPointDArray(Result, x1-x2, True);
     for i:= 0 to x1 - x2 -1 do
     begin
       Result[i].X := x1 -i;
@@ -896,7 +896,7 @@ begin
     if y1 = y2 then Exit;
     dxdy := (pt2.X - pt1.X)/(pt2.Y - pt1.Y);
     yo := y1 -pt1.Y;
-    SetLength(Result, y2-y1);
+    NewPointDArray(Result, y2-y1, True);
     for i:= 0 to y2 - y1 -1 do
     begin
       Result[i].Y := y1 +i;
@@ -909,7 +909,7 @@ begin
     if y1 = y2 then Exit;
     dxdy := (pt2.X - pt1.X)/(pt2.Y - pt1.Y);
     yo := y1 -pt1.Y;
-    SetLength(Result, y1-y2);
+    NewPointDArray(Result, y1-y2, True);
     for i:= 0 to y1 - y2 -1 do
     begin
       Result[i].Y := y1 -i;

--- a/source/Img32.Vector.pas
+++ b/source/Img32.Vector.pas
@@ -253,6 +253,7 @@ type
 
   //function MakePath(const pts: array of integer): TPathD; overload;
   function MakePath(const pts: array of double): TPathD; overload;
+  function MakePath(const pt: TPointD): TPathD; overload;
 
   function GetBounds(const path: TPathD): TRect; overload;
   function GetBounds(const paths: TPathsD): TRect; overload;
@@ -1845,7 +1846,7 @@ var
 begin
   len := length(path);
   if (len > 0) and PointsEqual(pt, path[len -1]) then Exit;
-  setLength(path, len + 1);
+  SetLengthUninit(path, len + 1);
   path[len] := pt;
 end;
 //------------------------------------------------------------------------------
@@ -1858,7 +1859,7 @@ begin
   len2 := length(path2);
   if len2 = 0 then Exit;
   if (len1 > 0) and PointsEqual(path2[0], path1[len1 -1]) then dec(len1);
-  setLength(path1, len1 + len2);
+  SetLengthUninit(path1, len1 + len2);
   Move(path2[0], path1[len1], len2 * SizeOf(TPointD));
 end;
 //------------------------------------------------------------------------------
@@ -1868,7 +1869,7 @@ var
   len: integer;
 begin
   len := length(path);
-  SetLength(path, len +1);
+  SetLengthUninit(path, len +1);
   path[len] := extra;
 end;
 //------------------------------------------------------------------------------
@@ -1929,7 +1930,7 @@ begin
       inc(len, pathLen);
     end;
   end;
-  SetLength(dstPath, len);
+  SetLengthUninit(dstPath, len);
 
   // fill the array
   len := 0;
@@ -2221,7 +2222,7 @@ var
     if resCnt >= resCap then
     begin
       inc(resCap, 64);
-      setLength(result, resCap);
+      SetLengthUninit(result, resCap);
     end;
     result[resCnt] := pt;
     inc(resCnt);
@@ -2483,7 +2484,7 @@ var
     if resCnt >= resCap then
     begin
       inc(resCap, 64);
-      setLength(result, resCap);
+      SetLengthUninit(result, resCap);
     end;
     result[resCnt] := pt;
     inc(resCnt);
@@ -3231,7 +3232,7 @@ var
 begin
   result := Arc(rec, StartAngle, EndAngle, scale);
   len := length(result);
-  setLength(result, len +1);
+  SetLengthUninit(result, len +1);
   result[len] := PointD((rec.Left + rec.Right)/2, (rec.Top + rec.Bottom)/2);
 end;
 //------------------------------------------------------------------------------
@@ -3664,7 +3665,7 @@ var
     if resultCnt = resultLen then
     begin
       inc(resultLen, BuffSize);
-      setLength(result, resultLen);
+      SetLengthUninit(result, resultLen);
     end;
     result[resultCnt] := pt;
     inc(resultCnt);
@@ -3775,7 +3776,7 @@ var
     if resultCnt = resultLen then
     begin
       inc(resultLen, BuffSize);
-      setLength(result, resultLen);
+      SetLengthUninit(result, resultLen);
     end;
     result[resultCnt] := pt;
     inc(resultCnt);
@@ -3857,7 +3858,7 @@ var
     if resultCnt = resultLen then
     begin
       inc(resultLen, BuffSize);
-      setLength(result, resultLen);
+      SetLengthUninit(result, resultLen);
     end;
     result[resultCnt] := pt;
     inc(resultCnt);
@@ -3870,10 +3871,7 @@ var
     if (abs(p1.x + p3.x - 2*p2.x) + abs(p2.x + p4.x - 2*p3.x) +
       abs(p1.y + p3.y - 2*p2.y) + abs(p2.y + p4.y - 2*p3.y)) < tolerance then
     begin
-      if resultCnt = length(result) then
-        setLength(result, length(result) +BuffSize);
-      result[resultCnt] := p4;
-      inc(resultCnt);
+      AddPoint(p4);
     end else
     begin
       p12.X := (p1.X + p2.X) / 2;
@@ -3945,7 +3943,7 @@ var
     if resultCnt = resultLen then
     begin
       inc(resultLen, BuffSize);
-      setLength(result, resultLen);
+      SetLengthUninit(result, resultLen);
     end;
     result[resultCnt] := pt;
     inc(resultCnt);
@@ -4000,7 +3998,7 @@ end;
 
 function MakePath(const pts: array of double): TPathD;
 var
-  i, j, len: Integer;
+  i, len: Integer;
   x,y: double;
 begin
   Result := nil;
@@ -4009,16 +4007,20 @@ begin
   NewPointDArray(Result, len, True);
   Result[0].X := pts[0];
   Result[0].Y := pts[1];
-  j := 0;
   for i := 1 to len -1 do
   begin
     x := pts[i*2];
     y := pts[i*2 +1];
-    inc(j);
-    Result[j].X := x;
-    Result[j].Y := y;
+    Result[i].X := x;
+    Result[i].Y := y;
   end;
-  setlength(Result, j+1);
+end;
+//------------------------------------------------------------------------------
+
+function MakePath(const pt: TPointD): TPathD;
+begin
+  SetLengthUninit(Result, 1);
+  Result[0] := pt;
 end;
 //------------------------------------------------------------------------------
 

--- a/source/Img32.Vector.pas
+++ b/source/Img32.Vector.pas
@@ -668,7 +668,7 @@ var
   i,j, len: integer;
 begin
   len := length(path);
-  SetLength(Result, len);
+  NewPointDArray(Result, len, True);
   if len = 0 then Exit;
   Result[0] := path[0];
   j := 0;
@@ -951,7 +951,7 @@ var
   i, len: integer;
 begin
   len := Length(ints);
-  SetLength(Result, len);
+  NewIntegerArray(Result, len, True);
   for i := 0 to len -1 do Result[i] := ints[i];
 end;
 //------------------------------------------------------------------------------
@@ -1152,7 +1152,7 @@ var
   i, len: integer;
 begin
   len := length(path);
-  setLength(result, len);
+  NewPointDArray(result, len, True);
   for i := 0 to len -1 do
   begin
     result[i].x := path[i].x + dx;
@@ -1210,7 +1210,7 @@ begin
   end else
   begin
     len := length(path);
-    setLength(result, len);
+    NewPointDArray(result, len, True);
     for i := 0 to len -1 do
     begin
       result[i].x := path[i].x * sx;
@@ -1327,7 +1327,7 @@ var
   i, highI: integer;
 begin
   highI := High(path);
-  SetLength(result, highI +1);
+  NewPointDArray(result, highI +1, True);
   for i := 0 to highI do
     result[i] := path[highI -i];
 end;
@@ -1350,7 +1350,7 @@ var
 begin
   len := Length(path);
   len2 := Max(0, len - 2);
-  setLength(Result, len + len2);
+  NewPointDArray(Result, len + len2, True);
   if len = 0 then Exit;
   Move(path[0], Result[0], len * SizeOf(TPointD));
   if len2 = 0 then Exit;
@@ -1365,7 +1365,7 @@ var
   pt: TPointD;
 begin
   len := length(path);
-  setLength(result, len);
+  NewPointDArray(result, len, True);
   if len = 0 then Exit;
   pt := path[0];
   //skip duplicates
@@ -1403,7 +1403,7 @@ var
   last: TPointD;
 begin
   highI := High(path);
-  setLength(result, highI+1);
+  NewPointDArray(result, highI+1, True);
   if highI < 0 then Exit;
 
   last := NullPointD;
@@ -1984,7 +1984,7 @@ var
   i: integer;
   x,y: double;
 begin
-  SetLength(Result, length(path));
+  NewPointDArray(Result, length(path), True);
   for i := 0 to high(path) do
   begin
     x := path[i].X - focalPoint.X;
@@ -2812,7 +2812,7 @@ end;
 
 function Rectangle(const rec: TRect): TPathD;
 begin
-  setLength(Result, 4);
+  NewPointDArray(Result, 4, True);
   with rec do
   begin
     result[0] := PointD(left, top);
@@ -2825,7 +2825,7 @@ end;
 
 function Rectangle(const rec: TRectD): TPathD;
 begin
-  setLength(Result, 4);
+  NewPointDArray(Result, 4, True);
   with rec do
   begin
     result[0] := PointD(left, top);
@@ -2838,7 +2838,7 @@ end;
 
 function Rectangle(l, t, r, b: double): TPathD;
 begin
-  setLength(Result, 4);
+  NewPointDArray(Result, 4, True);
   result[0] := PointD(l, t);
   result[1] := PointD(r, t);
   result[2] := PointD(r, b);
@@ -2927,7 +2927,7 @@ begin
   end;
   magic.X := radius.X * magicC;
   magic.Y := radius.Y * magicC;
-  SetLength(Corners, 4);
+  NewPointDArray(Corners, 4, True);
   with rec do
   begin
     corners[0] := PointD(Right, Top);
@@ -2935,10 +2935,10 @@ begin
     corners[2] := PointD(Left, Bottom);
     corners[3] := TopLeft;
   end;
-  SetLength(Result, 1);
+  NewPointDArray(Result, 1, True);
   Result[0].X := corners[3].X + radius.X;
   Result[0].Y := corners[3].Y;
-  SetLength(bezPts, 4);
+  NewPointDArray(bezPts, 4, True);
   for i := 0 to High(corners) do
   begin
     for j := 0 to 3 do bezPts[j] := corners[i];
@@ -3073,7 +3073,7 @@ begin
     steps := Round(CalcRoundingSteps(rec.width + rec.height));
   GetSinCos(2 * Pi / Steps, sinA, cosA);
   delta.x := cosA; delta.y := sinA;
-  SetLength(Result, Steps);
+  NewPointDArray(Result, Steps, True);
   Result[0] := PointD(centre.X + radius.X, centre.Y);
   for i := 1 to steps -1 do
   begin
@@ -3134,7 +3134,7 @@ begin
   if rec2.IsEmpty then
     p2 := Ellipse(rec, points*2) else
     p2 := Ellipse(rec2, points*2);
-  SetLength(Result, points*2);
+  NewPointDArray(Result, points*2, True);
   for i := 0 to points -1 do
   begin
     Result[i*2] := p[i];
@@ -3156,7 +3156,7 @@ begin
   else points := points * 2;
   GetSinCos(2 * Pi / points, sinA, cosA);
   delta.x := cosA; delta.y := sinA;
-  SetLength(Result, points);
+  NewPointDArray(Result, points, True);
   Result[0] := PointD(focalPt.X + innerRadius, focalPt.Y);
   for i := 1 to points -1 do
   begin
@@ -3206,7 +3206,7 @@ begin
   steps := Round(CalcRoundingSteps((rec.width + rec.height)/2 * scale));
   steps := steps div 2; /////////////////////////////////
   if steps < 2 then steps := 2;
-  SetLength(Result, Steps +1);
+  NewPointDArray(Result, Steps +1, True);
   //angle of the first step ...
   GetSinCos(startAngle, deltaY, deltaX);
   Result[0].X := centre.X + radius.X * deltaX;
@@ -3253,7 +3253,7 @@ begin
       Exit;
     asSimple:
       begin
-        setLength(result, 3);
+        NewPointDArray(result, 3, True);
         basePt := TranslatePoint(arrowTip, -unitVec.X * size, -unitVec.Y * size);
         result[0] := arrowTip;
         result[1] := TranslatePoint(basePt, -unitVec.Y * sDiv50, unitVec.X * sDiv50);
@@ -3261,7 +3261,7 @@ begin
       end;
     asFancy:
       begin
-        setLength(result, 4);
+        NewPointDArray(result, 4, True);
         basePt := TranslatePoint(arrowTip,
           -unitVec.X * sDiv120, -unitVec.Y * sDiv120);
         result[0] := TranslatePoint(basePt, -unitVec.Y *sDiv50, unitVec.X *sDiv50);
@@ -3271,7 +3271,7 @@ begin
       end;
     asDiamond:
       begin
-        setLength(result, 4);
+        NewPointDArray(result, 4, True);
         basePt := TranslatePoint(arrowTip, -unitVec.X * sDiv60, -unitVec.Y * sDiv60);
         result[0] := arrowTip;
         result[1] := TranslatePoint(basePt, -unitVec.Y * sDiv50, unitVec.X * sDiv50);
@@ -3286,7 +3286,7 @@ begin
       end;
     asTail:
       begin
-        setLength(result, 6);
+        NewPointDArray(result, 6, True);
         basePt := TranslatePoint(arrowTip, -unitVec.X * sDiv60, -unitVec.Y * sDiv60);
         result[0] := TranslatePoint(arrowTip, -unitVec.X * sDiv50, -unitVec.Y * sDiv50);
         result[1] := TranslatePoint(arrowTip, -unitVec.Y * sDiv40, unitVec.X * sDiv40);
@@ -3587,7 +3587,7 @@ var
   len: integer;
 begin
   len := Length(p);
-  SetLength(Result, len +1);
+  NewPointDArray(Result, len +1, True);
   Result[0] := pt;
   if len > 0 then Move(p[0], Result[1], len * SizeOf(TPointD));
 end;
@@ -3598,7 +3598,7 @@ var
   len: integer;
 begin
   len := Length(p);
-  SetLength(Result, len +2);
+  NewPointDArray(Result, len +2, True);
   Result[0] := pt1;
   Result[1] := pt2;
   if len > 0 then Move(p[0], Result[2], len * SizeOf(TPointD));
@@ -3636,7 +3636,7 @@ begin
   if (highI < 2) or Odd(highI) then
     raise Exception.Create(rsInvalidQBezier);
   if tolerance <= 0.0 then tolerance := BezierTolerance;
-  setLength(Result, 1);
+  NewPointDArray(Result, 1, True);
   Result[0] := pts[0];
   for i := 0 to (highI div 2) -1 do
   begin
@@ -3735,7 +3735,7 @@ begin
   if (len < 3) or (len mod 3 <> 0) then
     raise Exception.Create(rsInvalidCBezier);
   if tolerance <= 0.0 then tolerance := BezierTolerance;
-  setLength(Result, 1);
+  NewPointDArray(Result, 1, True);
   Result[0] := path[0];
   for i := 0 to (len div 3) -1 do
   begin
@@ -3839,7 +3839,7 @@ var
   len: integer;
 begin
   len := Length(pts);
-  SetLength(p, len + 2);
+  NewPointDArray(p, len + 2, True);
   p[0] := startPt;
   p[1] := ReflectPoint(priorCtrlPt, startPt);
   if len > 0 then
@@ -3927,7 +3927,7 @@ var
   len: integer;
 begin
   len := Length(pts);
-  SetLength(p, len + 2);
+  NewPointDArray(p, len + 2, True);
   p[0] := startPt;
   p[1] := ReflectPoint(priorCtrlPt, startPt);
   if len > 0 then
@@ -4006,7 +4006,7 @@ begin
   Result := nil;
   len := length(pts) div 2;
   if len = 0 then Exit;
-  setlength(Result, len);
+  NewPointDArray(Result, len, True);
   Result[0].X := pts[0];
   Result[0].Y := pts[1];
   j := 0;

--- a/source/Img32.Vectorizer.pas
+++ b/source/Img32.Vectorizer.pas
@@ -93,7 +93,7 @@ var
   i, len: integer;
 begin
   len := GetVertexCount(pt);
-  SetLength(Result, len);
+  NewPointDArray(Result, len, True);
   for i := 0 to len -1 do
   begin
     Result[i] := PointD(pt.X, pt.Y);


### PR DESCRIPTION
This PR changes the way dynamic TColor32 arrays are created. A SetLength() call always fills the array with zeros, but a lot of Image32 code overwrites the whole array immediately. So this extra FillChar(0) call is not necessary. And that is what the new `NewColor32Array()` and `SetLengthUninit()` functions do. They create/change the length of a Delphi/FPC dynamic array without filling them with zeros.

This only works for non-managed element types because managed element types need the zero-fill to work properly. So only primitive types.

**Added functions:**
- NewColor32Array
- NewPointDArray {TPathD}
- NewIntegerArray
- NewByteArray
- SetLengthUninit(TArrayOfColor32)
- SetLengthUninit(TArrayOfInteger)
- SetLengthUninit(TArrayOfByte)
- SetLengthUninit(TPathD)

The "New" in NewColor32Array() really means new, not change the length. It sets the array to nil before allocating a new array. So it isn't a simple replacement for every SetLength() call. That's what the SetLengthUninit is for. The difference between those two is, that NewColor32Array() doesn't preserve any former content whereas SetLengthUninit keeps the already existing elements if they are not truncated.