### PR TITLE
Smaller performance patches

### DIFF
--- a/source/Img32.Extra.pas
+++ b/source/Img32.Extra.pas
@@ -107,7 +107,8 @@ procedure EraseInsidePaths(img: TImage32;
 procedure EraseOutsidePath(img: TImage32; const path: TPathD;
   fillRule: TFillRule; const outsideBounds: TRect);
 procedure EraseOutsidePaths(img: TImage32; const paths: TPathsD;
-  fillRule: TFillRule; const outsideBounds: TRect);
+  fillRule: TFillRule; const outsideBounds: TRect;
+  rendererCache: TCustomColorRendererCache = nil); overload;
 
 procedure Draw3D(img: TImage32; const polygon: TPathD;
   fillRule: TFillRule; height, blurRadius: double;
@@ -675,47 +676,60 @@ procedure GridBackground(img: TImage32; majorInterval, minorInterval: integer;
 var
   i, x,y, w,h: integer;
   path: TPathD;
+  cr: TCustomColorRenderer;
 begin
   img.Clear(fillColor);
   w := img.Width; h := img.Height;
   NewPointDArray(path, 2, True);
-  if minorInterval > 0 then
-  begin
-    x := minorInterval;
-    path[0] := PointD(x, 0); path[1] := PointD(x, h);;
-    for i := 1 to (w div minorInterval) do
+
+  if img.AntiAliased then
+    cr := TColorRenderer.Create(minColor) else
+    cr := TAliasedColorRenderer.Create(minColor);
+  try
+    if minorInterval > 0 then
     begin
-      Img32.Draw.DrawLine(img, path, 1, minColor, esSquare);
-      path[0].X := path[0].X + minorInterval;
-      path[1].X := path[1].X + minorInterval;
+      //cr.SetColor(minColor);
+
+      x := minorInterval;
+      path[0] := PointD(x, 0); path[1] := PointD(x, h);;
+      for i := 1 to (w div minorInterval) do
+      begin
+        Img32.Draw.DrawLine(img, path, 1, cr, esSquare);
+        path[0].X := path[0].X + minorInterval;
+        path[1].X := path[1].X + minorInterval;
+      end;
+      y := minorInterval;
+      path[0] := PointD(0, y); path[1] := PointD(w, y);
+      for i := 1 to (h div minorInterval) do
+      begin
+        Img32.Draw.DrawLine(img, path, 1, cr, esSquare);
+        path[0].Y := path[0].Y + minorInterval;
+        path[1].Y := path[1].Y + minorInterval;
+      end;
     end;
-    y := minorInterval;
-    path[0] := PointD(0, y); path[1] := PointD(w, y);
-    for i := 1 to (h div minorInterval) do
+    if majorInterval > minorInterval then
     begin
-      Img32.Draw.DrawLine(img, path, 1, minColor, esSquare);
-      path[0].Y := path[0].Y + minorInterval;
-      path[1].Y := path[1].Y + minorInterval;
+      cr.SetColor(majColor);
+
+      x := majorInterval;
+      path[0] := PointD(x, 0); path[1] := PointD(x, h);;
+      for i := 1 to (w div majorInterval) do
+      begin
+        Img32.Draw.DrawLine(img, path, 1, cr, esSquare);
+        path[0].X := path[0].X + majorInterval;
+        path[1].X := path[1].X + majorInterval;
+      end;
+      y := majorInterval;
+      path[0] := PointD(0, y); path[1] := PointD(w, y);
+      for i := 1 to (h div majorInterval) do
+      begin
+        Img32.Draw.DrawLine(img, path, 1, cr, esSquare);
+        path[0].Y := path[0].Y + majorInterval;
+        path[1].Y := path[1].Y + majorInterval;
+      end;
     end;
-  end;
-  if majorInterval > minorInterval then
-  begin
-    x := majorInterval;
-    path[0] := PointD(x, 0); path[1] := PointD(x, h);;
-    for i := 1 to (w div majorInterval) do
-    begin
-      Img32.Draw.DrawLine(img, path, 1, majColor, esSquare);
-      path[0].X := path[0].X + majorInterval;
-      path[1].X := path[1].X + majorInterval;
-    end;
-    y := majorInterval;
-    path[0] := PointD(0, y); path[1] := PointD(w, y);
-    for i := 1 to (h div majorInterval) do
-    begin
-      Img32.Draw.DrawLine(img, path, 1, majColor, esSquare);
-      path[0].Y := path[0].Y + majorInterval;
-      path[1].Y := path[1].Y + majorInterval;
-    end;
+  finally
+    cr.Free;
   end;
 end;
 //------------------------------------------------------------------------------
@@ -945,7 +959,8 @@ end;
 //------------------------------------------------------------------------------
 
 procedure EraseOutsidePaths(img: TImage32; const paths: TPathsD;
-  fillRule: TFillRule; const outsideBounds: TRect);
+  fillRule: TFillRule; const outsideBounds: TRect;
+  rendererCache: TCustomColorRendererCache);
 var
   mask: TImage32;
   pp: TPathsD;
@@ -956,7 +971,7 @@ begin
   mask := TImage32.Create(w, h);
   try
     pp := TranslatePath(paths, -outsideBounds.Left, -outsideBounds.top);
-    DrawPolygon(mask, pp, fillRule, clBlack32);
+    DrawPolygon(mask, pp, fillRule, clBlack32, rendererCache);
     img.CopyBlend(mask, mask.Bounds, outsideBounds, BlendMaskLine);
   finally
     mask.Free;

--- a/source/Img32.Resamplers.pas
+++ b/source/Img32.Resamplers.pas
@@ -781,7 +781,7 @@ end;
 procedure NearestNeighborResize(Image, TargetImage: TImage32; newWidth, newHeight: Integer);
 var
   x, y, offset: Integer;
-  scaledXi, scaledYi: TArrayOfInteger;
+  scaledXi, scaledYiOffset: TArrayOfInteger;
   tmp: TArrayOfColor32;
   pc: PColor32;
   pixels: TArrayOfColor32;
@@ -799,16 +799,18 @@ begin
   //get scaled X & Y values once only (storing them in lookup arrays) ...
   NewIntegerArray(scaledXi, newWidth, True);
   for x := 0 to newWidth -1 do
-    scaledXi[x] := Trunc(x * Image.Width / newWidth);
-  NewIntegerArray(scaledYi, newHeight, True);
+    scaledXi[x] := (x * Image.Width) div newWidth;
+  NewIntegerArray(scaledYiOffset, newHeight, True);
+  SetLength(scaledYiOffset, newHeight);
   for y := 0 to newHeight -1 do
-    scaledYi[y] := Trunc(y * Image.Height / newHeight);
+    //scaledYiOffset[y] := Round(y * Image.Height / newHeight) * Image.Width;
+    scaledYiOffset[y] := ((y * Image.Height) div newHeight) * Image.Width;
 
   pc := @tmp[0];
   pixels := Image.Pixels;
   for y := 0 to newHeight - 1 do
   begin
-    offset := scaledYi[y] * Image.Width;
+    offset := scaledYiOffset[y];
     for x := 0 to newWidth - 1 do
     begin
       pc^ := pixels[scaledXi[x] + offset];

--- a/source/Img32.Resamplers.pas
+++ b/source/Img32.Resamplers.pas
@@ -75,7 +75,7 @@ function BilinearResample(img: TImage32; x, y: double): TColor32;
 var
   iw, ih: integer;
   xx, yy, xR, yB: integer;
-  weight: Cardinal;
+  weight: integer;
   pixels: TArrayOfColor32;
   weightedColor: TWeightedColor;
   xf, yf: double;
@@ -179,7 +179,7 @@ function WeightedBilinearResample(img: TImage32; x, y: double): TColor32;
 var
   iw, ih: integer;
   xx, yy, xR, yB: integer;
-  weight: Cardinal;
+  weight: integer;
   pixels: TArrayOfColor32;
   weightedColor: TWeightedColor;
   xf, yf: double;

--- a/source/Img32.SVG.Path.pas
+++ b/source/Img32.SVG.Path.pas
@@ -1235,10 +1235,22 @@ end;
 function TSvgSubPath.GetSimplePath: TPathD;
 var
   i: integer;
+  paths: TPathsD;
 begin
-  Result := Img32.Vector.MakePath(GetFirstPt);
-  for i := 0 to High(fSegs) do
-    AppendPath(Result, fSegs[i].GetOnPathCtrlPts);
+  if Length(fSegs) <= 1 then
+  begin
+    Result := Img32.Vector.MakePath(GetFirstPt);
+    for i := 0 to High(fSegs) do
+      AppendPath(Result, fSegs[i].GetOnPathCtrlPts);
+  end
+  else
+  begin
+    SetLength(paths, 1 + Length(fSegs));
+    paths[0] := Img32.Vector.MakePath(GetFirstPt);
+    for i := 0 to High(fSegs) do
+      paths[1 + i] := fSegs[i].GetOnPathCtrlPts;
+    ConcatPaths(Result, paths);
+  end;
 end;
 //------------------------------------------------------------------------------
 

--- a/source/Img32.SVG.Path.pas
+++ b/source/Img32.SVG.Path.pas
@@ -1097,11 +1097,20 @@ begin
   if (pendingScale > fPendingScale) then
     fPendingScale := pendingScale;
 
-  Result := nil;
-  SetLength(flattenedPaths, Length(fSegs));
-  for i := 0 to High(fSegs) do
-    flattenedPaths[i] := fSegs[i].GetFlattened;
-  ConcatPaths(Result, flattenedPaths);
+  if Length(fSegs) <= 1 then
+  begin
+    Result := Img32.Vector.MakePath(GetFirstPt);
+    if fSegs <> nil then
+      AppendPath(Result, fSegs[0].GetOnPathCtrlPts);
+  end
+  else
+  begin
+    Result := nil;
+    SetLength(flattenedPaths, Length(fSegs));
+    for i := 0 to High(fSegs) do
+      flattenedPaths[i] := fSegs[i].GetFlattened;
+    ConcatPaths(Result, flattenedPaths);
+  end;
 end;
 //------------------------------------------------------------------------------
 
@@ -1240,8 +1249,8 @@ begin
   if Length(fSegs) <= 1 then
   begin
     Result := Img32.Vector.MakePath(GetFirstPt);
-    for i := 0 to High(fSegs) do
-      AppendPath(Result, fSegs[i].GetOnPathCtrlPts);
+    if fSegs <> nil then
+      AppendPath(Result, fSegs[0].GetOnPathCtrlPts);
   end
   else
   begin

--- a/source/Img32.Transform.pas
+++ b/source/Img32.Transform.pas
@@ -1175,16 +1175,15 @@ end;
 
 procedure TWeightedColor.Add(c: TColor32; w: Integer);
 var
-  a: Int64;
-  argb: TARGB absolute c;
+  a: Cardinal;
 begin
   inc(fAddCount, w);
-  a := w * argb.A;
+  a := w * Byte(c shr 24);
   if a = 0 then Exit;
   inc(fAlphaTot, a);
-  inc(fColorTotB, (a * argb.B));
-  inc(fColorTotG, (a * argb.G));
-  inc(fColorTotR, (a * argb.R));
+  inc(fColorTotB, (a * Byte(c)));
+  inc(fColorTotG, (a * Byte(c shr 8)));
+  inc(fColorTotR, (a * Byte(c shr 16)));
 end;
 //------------------------------------------------------------------------------
 
@@ -1215,16 +1214,15 @@ end;
 
 procedure TWeightedColor.Subtract(c: TColor32; w: Integer);
 var
-  a: Int64;
-  argb: TARGB absolute c;
+  a: Cardinal;
 begin
   dec(fAddCount, w);
-  a := w * argb.A;
+  a := w * Byte(c shr 24);
   if a = 0 then Exit;
   dec(fAlphaTot, a);
-  dec(fColorTotB, (a * argb.B));
-  dec(fColorTotG, (a * argb.G));
-  dec(fColorTotR, (a * argb.R));
+  dec(fColorTotB, (a * Byte(c)));
+  dec(fColorTotG, (a * Byte(c shr 8)));
+  dec(fColorTotR, (a * Byte(c shr 16)));
 end;
 //------------------------------------------------------------------------------
 

--- a/source/Img32.pas
+++ b/source/Img32.pas
@@ -2272,7 +2272,6 @@ begin
 end;
 //------------------------------------------------------------------------------
 
-
 procedure TImage32.Assign(src: TImage32);
 begin
   if assigned(src) then
@@ -2287,15 +2286,17 @@ begin
   try
     dst.AssignSettings(Self);
     try
-      dst.SetSize(Width, Height);
-      if (Width > 0) and (Height > 0) then
-        move(fPixels[0], dst.fPixels[0], Width * Height * SizeOf(TColor32));
+      dst.fPixels := System.Copy(fPixels, 0, Length(fPixels));
+      dst.fWidth := fWidth;
+      dst.fHeight := fHeight;
+      dst.Resized;
     except
       dst.SetSize(0,0);
     end;
   finally
     dst.EndUpdate;
   end;
+  dst.fColorCount := fColorCount; // dst.EndUpdate called ResetColorCount
 end;
 //------------------------------------------------------------------------------
 

--- a/source/Img32.pas
+++ b/source/Img32.pas
@@ -3641,51 +3641,43 @@ end;
 
 procedure TImage32.SetRGB(rgbColor: TColor32);
 var
-  rgb: TARGB absolute rgbColor;
-  r,g,b: Byte;
   i: Integer;
-  pc: PARGB;
+  pc: PColor32;
+  c: TColor32;
 begin
   //this method leaves the alpha channel untouched
   if IsEmpty then Exit;
-  r := rgb.R; g := rgb.G; b := rgb.B;
-  pc := PARGB(PixelBase);
-  for i := 0 to Width * Height -1 do
-    if pc.A = 0 then
-    begin
-      pc.Color := 0;
-      inc(pc);
-    end else
-    begin
-      pc.R := r;
-      pc.G := g;
-      pc.B := b;
-      inc(pc);
-    end;
+
+  pc := PixelBase;
+  rgbColor := rgbColor and $00FFFFFF;
+  for i := 0 to Width * Height - 1 do
+  begin
+    c := pc^;
+    if c and $FF000000 = 0 then
+      pc^ := 0 else
+      pc^ := c and $FF000000 or rgbColor;
+    inc(pc);
+  end;
   Changed;
 end;
 //------------------------------------------------------------------------------
 
 procedure TImage32.SetRGB(rgbColor: TColor32; rec: TRect);
 var
-  rgb: TARGB absolute rgbColor;
-  r,g,b: Byte;
   i,j, dx: Integer;
-  pc: PARGB;
+  pc: PColor32;
 begin
   Types.IntersectRect(rec, rec, bounds);
   if IsEmptyRect(rec) then Exit;
-  r := rgb.R; g := rgb.G; b := rgb.B;
-  pc := PARGB(PixelBase);
+  rgbColor := rgbColor and $00FFFFFF;
+  pc := PixelBase;
   inc(pc, rec.Left);
   dx := Width - RectWidth(rec);
   for i := rec.Top to rec.Bottom -1 do
   begin
     for j := rec.Left to rec.Right -1 do
     begin
-      pc.R := r;
-      pc.G := g;
-      pc.B := b;
+      pc^ := pc^ and $FF000000 or rgbColor;
       inc(pc);
     end;
     inc(pc, dx);


### PR DESCRIPTION
This PR improves the performance of some functions. The largest change is the introduction of TCustomColorRendererCache that helps the SvgReader to not create TColorRederer/TAliasedColorRenderer objects for every DrawPolygon call. That reduced the number of memory allocations, deallocations and FillChar calls especially for SVGs with lots of elements.

Changes:
- Fix: BilinearResample/WeightedBilinearResample could call TWeightedColor.Add/AddWeight with a negative "Weight" parameter due to a Cardinal underflow that circumvented the "if weight > 0 then".
- Performance: Removes "absolute" from TWeightedColor.Add/Subtract
- Performance: Replaces the NearestNeighborResize floating point scale-calculation with an integer calculation and changes the scaledYi array to an scaledYiOffset array, that also contains the additional offset calculation, so that the offset mustn't be calculated in the for-loop.
- Performance: Removes the SetSize call from TImage32.AssignTo to remove an unnecessary zero-ing of the pixels array.
- Performance: Don't use ConcatPaths for the simple case (1 start point + 1 segment)
- Performance: Removes "absolute" from TImage32.SetRGB
- Performance: TSvgReader now uses a single (mutable) TColorRenderer/TAliasedColorRenderer instance for the DrawPolygon/DrawLine/DrawDashedLine/EraseOutsidePaths calls instead of creating it for every call.