### PR TITLE
EraseOutsidePaths optimization

### DIFF
--- a/source/Img32.Extra.pas
+++ b/source/Img32.Extra.pas
@@ -108,7 +108,7 @@ procedure EraseOutsidePath(img: TImage32; const path: TPathD;
   fillRule: TFillRule; const outsideBounds: TRect);
 procedure EraseOutsidePaths(img: TImage32; const paths: TPathsD;
   fillRule: TFillRule; const outsideBounds: TRect;
-  rendererCache: TCustomColorRendererCache = nil); overload;
+  rendererCache: TCustomRendererCache = nil); overload;
 
 procedure Draw3D(img: TImage32; const polygon: TPathD;
   fillRule: TFillRule; height, blurRadius: double;
@@ -938,43 +938,89 @@ begin
 end;
 //------------------------------------------------------------------------------
 
+procedure EraseOutsideRect(img: TImage32; const r, outsideBounds: TRect);
+begin
+  // Fill the parts, that are in outsideBounds but not in r with zeros
+
+  // whole top block
+  if r.Top > outsideBounds.Top then
+    img.FillRect(Rect(outsideBounds.Left, outsideBounds.Top, outsideBounds.Right, r.Top - 1), 0);
+  // whole bottom block
+  if r.Bottom < outsideBounds.Bottom then
+    img.FillRect(Rect(outsideBounds.Left, r.Bottom + 1, outsideBounds.Right, outsideBounds.Bottom), 0);
+
+  // remaining left block
+  if r.Left > outsideBounds.Left then
+    img.FillRect(Rect(outsideBounds.Left, r.Top, r.Left - 1, r.Bottom), 0);
+  // remaining right block
+  if r.Right < outsideBounds.Right then
+    img.FillRect(Rect(r.Right + 1, r.Top, outsideBounds.Right, r.Bottom), 0);
+end;
+//------------------------------------------------------------------------------
+
 procedure EraseOutsidePath(img: TImage32; const path: TPathD;
   fillRule: TFillRule; const outsideBounds: TRect);
 var
-  mask: TImage32;
-  p: TPathD;
-  w,h: integer;
+  w, h: integer;
+  renderer: TMaskRenderer;
+  r: TRect;
+  polygons: TPathsD;
 begin
   if not assigned(path) then Exit;
-  RectWidthHeight(outsideBounds, w,h);
-  mask := TImage32.Create(w, h);
+  RectWidthHeight(outsideBounds, w, h);
+  if (w <= 0) or (h <= 0)  then Exit;
+
+  // We can skip the costly polygon rasterization if the path is
+  // a rectangle
+  if (fillRule in [frEvenOdd, frNonZero]) and IsSimpleRectanglePath(path, r) then
+  begin
+    EraseOutsideRect(img, r, outsideBounds);
+    Exit;
+  end;
+
+  renderer := TMaskRenderer.Create(outsideBounds);
   try
-    p := TranslatePath(path, -outsideBounds.Left, -outsideBounds.top);
-    DrawPolygon(mask, p, fillRule, clBlack32);
-    img.CopyBlend(mask, mask.Bounds, outsideBounds, BlendMaskLine);
+    SetLength(polygons, 1);
+    polygons[0] := path;
+    Rasterize(img, polygons, outsideBounds, fillRule, renderer);
   finally
-    mask.Free;
+    renderer.Free;
   end;
 end;
 //------------------------------------------------------------------------------
 
 procedure EraseOutsidePaths(img: TImage32; const paths: TPathsD;
   fillRule: TFillRule; const outsideBounds: TRect;
-  rendererCache: TCustomColorRendererCache);
+  rendererCache: TCustomRendererCache);
 var
-  mask: TImage32;
-  pp: TPathsD;
-  w,h: integer;
+  w, h: integer;
+  renderer: TMaskRenderer;
+  r: TRect;
 begin
   if not assigned(paths) then Exit;
-  RectWidthHeight(outsideBounds, w,h);
-  mask := TImage32.Create(w, h);
+  RectWidthHeight(outsideBounds, w, h);
+  if (w <= 0) or (h <= 0)  then Exit;
+
+  // We can skip the costly polygon rasterization if the path is
+  // a rectangle.
+  if (fillRule in [frEvenOdd, frNonZero]) and IsSimpleRectanglePath(paths, r) then
+  begin
+    EraseOutsideRect(img, r, outsideBounds);
+    Exit;
+  end;
+
+  if rendererCache = nil then
+    renderer := TMaskRenderer.Create(outsideBounds)
+  else
+  begin
+    renderer := rendererCache.MaskRenderer;
+    renderer.SetOutsideBounds(outsideBounds);
+  end;
   try
-    pp := TranslatePath(paths, -outsideBounds.Left, -outsideBounds.top);
-    DrawPolygon(mask, pp, fillRule, clBlack32, rendererCache);
-    img.CopyBlend(mask, mask.Bounds, outsideBounds, BlendMaskLine);
+    Rasterize(img, paths, outsideBounds, fillRule, renderer);
   finally
-    mask.Free;
+    if rendererCache = nil then
+      renderer.Free;
   end;
 end;
 //------------------------------------------------------------------------------

--- a/source/Img32.SVG.Reader.pas
+++ b/source/Img32.SVG.Reader.pas
@@ -120,7 +120,7 @@ type
     fClassStyles      : TClassStylesList;
     fLinGradRenderer  : TLinearGradientRenderer;
     fRadGradRenderer  : TSvgRadialGradientRenderer;
-    fCustomColorRendererCache: TCustomColorRendererCache;
+    fCustomRendererCache: TCustomRendererCache;
     fRootElement      : TSvgElement;
     fFontCache        : TFontCache;
     fUsePropScale     : Boolean;
@@ -1016,9 +1016,9 @@ begin
       begin
         if fDrawData.fillRule = frNegative then
           EraseOutsidePaths(tmpImg, clipPaths, frNonZero, clipRec,
-            fReader.fCustomColorRendererCache) else
+            fReader.fCustomRendererCache) else
           EraseOutsidePaths(tmpImg, clipPaths, fDrawData.fillRule, clipRec,
-            fReader.fCustomColorRendererCache);
+            fReader.fCustomRendererCache);
       end;
       image.CopyBlend(tmpImg, clipRec, clipRec, BlendToAlphaLine);
     finally
@@ -2122,7 +2122,7 @@ begin
 
   // FastGaussianBlur is a very good approximation and also very much faster.
   // Empirically stdDev * PI/4 more closely emulates other renderers.
-  FastGaussianBlur(dstImg, dstRec, Ceil(stdDev * PI/4 * ParentFilterEl.fScale));
+  FastGaussianBlur(dstImg, dstRec, Ceil(stdDev * (PI/4) * ParentFilterEl.fScale));
 end;
 
 //------------------------------------------------------------------------------
@@ -2395,9 +2395,9 @@ begin
     begin
       if fDrawData.fillRule = frNegative then
         EraseOutsidePaths(img, clipPaths, frNonZero, clipRec2,
-          fReader.fCustomColorRendererCache) else
+          fReader.fCustomRendererCache) else
         EraseOutsidePaths(img, clipPaths, fDrawData.fillRule, clipRec2,
-          fReader.fCustomColorRendererCache);
+          fReader.fCustomRendererCache);
     end;
 
   if usingTempImage and (img <> image) then
@@ -2540,14 +2540,14 @@ begin
   else if drawDat.fillColor = clInvalid then
   begin
     DrawPolygon(img, fillPaths, drawDat.fillRule, clBlack32,
-      fReader.fCustomColorRendererCache);
+      fReader.fCustomRendererCache);
   end
   else
     with drawDat do
     begin
       DrawPolygon(img, fillPaths, fillRule,
         MergeColorAndOpacity(fillColor, fillOpacity),
-        fReader.fCustomColorRendererCache);
+        fReader.fCustomRendererCache);
     end;
 end;
 //------------------------------------------------------------------------------
@@ -2629,7 +2629,7 @@ begin
       strokePaths := MatrixApply(drawPathsO, drawDat.matrix);
       DrawDashedLine(img, strokePaths, dashArray,
         @dashOffset, sw * scale, strokeClr, endStyle, jsAuto,
-        fReader.fCustomColorRendererCache);
+        fReader.fCustomRendererCache);
       Exit;
     end;
     strokePaths := RoughOutline(drawPathsO, sw, joinStyle, endStyle, lim);
@@ -2662,7 +2662,7 @@ begin
       end;
   end else
   begin
-    DrawPolygon(img, strokePaths, frNonZero, strokeClr, fReader.fCustomColorRendererCache);
+    DrawPolygon(img, strokePaths, frNonZero, strokeClr, fReader.fCustomRendererCache);
   end;
 end;
 
@@ -4902,7 +4902,7 @@ begin
   fClassStyles        := TClassStylesList.Create;
   fLinGradRenderer  := TLinearGradientRenderer.Create;
   fRadGradRenderer  := TSvgRadialGradientRenderer.Create;
-  fCustomColorRendererCache := TCustomColorRendererCache.Create;
+  fCustomRendererCache := TCustomRendererCache.Create;
   fIdList             := TStringList.Create;
   fIdList.Duplicates  := dupIgnore;
   fIdList.CaseSensitive := false;
@@ -4925,7 +4925,7 @@ begin
 
   fLinGradRenderer.Free;
   fRadGradRenderer.Free;
-  fCustomColorRendererCache.Free;
+  fCustomRendererCache.Free;
   FreeAndNil(fFontCache);
   fSimpleDrawList.Free;
 

--- a/source/Img32.Vector.pas
+++ b/source/Img32.Vector.pas
@@ -275,6 +275,11 @@ type
 
   function IsClockwise(const path: TPathD): Boolean;
 
+  // IsSimpleRectanglePath returns true if the specified path has only one polygon
+  // with 4 points that describe a rectangle.
+  function IsSimpleRectanglePath(const paths: TPathsD; var R: TRect): Boolean; overload;
+  function IsSimpleRectanglePath(const path: TPathD; var R: TRect): Boolean; overload;
+
   function Area(const path: TPathD): Double; overload;
 
   function RectsEqual(const rec1, rec2: TRect): Boolean;
@@ -788,6 +793,63 @@ end;
 function IsClockwise(const path: TPathD): Boolean;
 begin
   Result := Area(path) > 0;
+end;
+//------------------------------------------------------------------------------
+
+function IsSimpleRectanglePath(const path: TPathD; var R: TRect): Boolean;
+type
+  TLastMatch = (lmX, lmY);
+var
+  i: Integer;
+  lastMatch: TLastMatch;
+begin
+  Result := False;
+  // If we have a single path with 4 points, it could be a rectangle
+  if Length(path) = 4 then
+  begin
+    // For a rectangle the X and Y coordinates of the points alternate
+    // in being equal
+    if path[0].X = path[3].X then
+      lastMatch := lmX
+    else if path[0].Y = path[3].Y then
+      lastMatch := lmY
+    else
+      Exit;
+
+    R.Left := Trunc(path[0].X);
+    R.Top := Trunc(path[0].Y);
+    R.Right := Ceil(path[0].X);
+    R.Bottom := Ceil(path[0].Y);
+    for i := 1 to 3 do
+    begin
+      case lastMatch of
+        lmY: // now the X-coordinates must be equal
+          begin
+            if path[i].X <> path[i - 1].X then Exit;
+            lastMatch := lmX;
+            R.Top := Min(R.Top, Trunc(path[i].Y));
+            R.Bottom := Max(R.Bottom, Ceil(path[i].Y));
+          end;
+        lmX: // now the Y-coordinates must be equal
+          begin
+            if path[i].Y <> path[i - 1].Y then Exit;
+            lastMatch := lmY;
+            R.Left := Min(R.Left, Trunc(path[i].X));
+            R.Right := Max(R.Right, Ceil(path[i].X));
+          end;
+      end;
+    end;
+    Result := True;
+  end;
+end;
+
+//------------------------------------------------------------------------------
+function IsSimpleRectanglePath(const paths: TPathsD; var R: TRect): Boolean;
+begin
+  if (Length(paths) = 1) and (Length(paths[0]) = 4) then
+    Result := IsSimpleRectanglePath(paths[0], r)
+  else
+    Result := False;
 end;
 //------------------------------------------------------------------------------
 


### PR DESCRIPTION
This PR introduces the new TMaskRenderer, that allows EraseOutsidePaths to directly modify the target image instead of drawing on a new image and then blending that with the target image. The TMaskRenderer clears all parts of the image that are not in the polygons.

EraseOutsidePaths can now skip the polygon MaskRenderer if the path is a simple rectangle. It then uses up to 4 FillRect calls for the areas that are not covered by the rectangle.

There are also some micro optimizations for BlendMaskLine and ReduceOpacity in this PR.