### PR TITLE
Fixes for the TMaskRenderer

### DIFF
--- a/source/Img32.Extra.pas
+++ b/source/Img32.Extra.pas
@@ -978,7 +978,7 @@ begin
     Exit;
   end;
 
-  renderer := TMaskRenderer.Create(outsideBounds);
+  renderer := TMaskRenderer.Create;
   try
     SetLength(polygons, 1);
     polygons[0] := path;
@@ -1010,12 +1010,9 @@ begin
   end;
 
   if rendererCache = nil then
-    renderer := TMaskRenderer.Create(outsideBounds)
+    renderer := TMaskRenderer.Create
   else
-  begin
     renderer := rendererCache.MaskRenderer;
-    renderer.SetOutsideBounds(outsideBounds);
-  end;
   try
     Rasterize(img, paths, outsideBounds, fillRule, renderer);
   finally


### PR DESCRIPTION
This PR fixes some bugs in the new TMaskRenderer.

There were some off-by-one bugs that could overwrite the first pixel in the next scanline. Also the ClipRect handling didn't match the CopyBlend function's interpretation. CopyBlend excludes Right/Bottom whereas TMaskRenderer included them. And because TMaskRenderer is a replacement for the `Polygon()+CopyBlend(BlendMask)` code that was in EraseOutsidePaths, it should give the exact same result.

The TMaskRenderer now also handles skipped scanlines for paths with disjunct polygons. For this the Rasterize() function has been extended to notify the renderer about the skipped scanlines.
