### PR TITLE
SVG parser performance optimizations

### DIFF
--- a/source/Img32.SVG.Core.pas
+++ b/source/Img32.SVG.Core.pas
@@ -27,10 +27,6 @@ uses
   {$ZEROBASEDSTRINGS OFF}
 {$ENDIF}
 
-{$IFOPT R+}
-  {$DEFINE OVERFLOWCHECKS_ENABLED}
-{$ENDIF}
-
 type
   TSvgEncoding = (eUnknown, eUtf8, eUnicodeLE, eUnicodeBE);
 
@@ -826,7 +822,6 @@ begin
   else
     val := v32;
 end;
-
 //------------------------------------------------------------------------------
 
 function ParseNextNumEx(var c: PUTF8Char; endC: PUTF8Char; skipComma: Boolean;
@@ -2537,9 +2532,7 @@ begin
   FCount := Count;
   SetLength(FItems, FCount);
 
-  FMod := FCount * 2; // gives us 3 color constants as max. bucket depth
-  if not Odd(FMod) then
-    Inc(FMod);
+  FMod := FCount * 2 + 1; // gives us 3 color constants as max. bucket depth
   SetLength(FBuckets, FMod);
 
   // Initialize FItems[] and fill the buckets
@@ -2554,6 +2547,7 @@ begin
     Bucket^ := Item;
   end;
 end;
+//------------------------------------------------------------------------------
 
 function TColorConstList.GetColorValue(const ColorName: UTF8String; var Color: TColor32): Boolean;
 var
@@ -2572,7 +2566,6 @@ begin
   else
     Result := False;
 end;
-
 
 //------------------------------------------------------------------------------
 // initialization procedures
@@ -2597,7 +2590,7 @@ end;
 
 procedure CleanupColorConstList;
 begin
-  ColorConstList.Free;
+  FreeAndNil(ColorConstList);
 end;
 
 //------------------------------------------------------------------------------

--- a/source/Img32.SVG.Core.pas
+++ b/source/Img32.SVG.Core.pas
@@ -372,6 +372,14 @@ end;
 // Miscellaneous functions ...
 //------------------------------------------------------------------------------
 
+function NewSvgAttrib(): PSvgAttrib; {$IFDEF INLINE} inline; {$ENDIF}
+begin
+  // New(Result) uses RTTI to initialize the UTF8String fields to nil.
+  // By allocating zero'ed memory we can achieve that much faster.
+  Result := AllocMem(SizeOf(TSvgAttrib));
+end;
+//------------------------------------------------------------------------------
+
 function GetScale(src, dst: double): double;
 begin
   Result := dst / src;
@@ -1536,7 +1544,7 @@ begin
       inc(c, 4); //ignore xml: prefixes
     end;
 
-    New(attrib);
+    attrib := NewSvgAttrib();
     if not ParseAttribName(c, endC, attrib) or
       not ParseAttribValue(c, endC, attrib) then
     begin
@@ -1611,7 +1619,7 @@ begin
     styleVal := ToTrimmedUTF8String(c2, c);
     inc(c);
 
-    new(attrib);
+    attrib := NewSvgAttrib();
     attrib.name := styleName;
     attrib.value := styleVal;
     attrib.hash := GetHash(attrib.name);
@@ -1764,7 +1772,7 @@ begin
       Continue;
     end;
     inc(c, 8);
-    new(attrib);
+    attrib := NewSvgAttrib();
     if not ParseAttribName(c, endC, attrib) then break;
     SkipBlanks(c, endC);
     if not (c^ in [quote, dquote]) then break;

--- a/source/Img32.SVG.Core.pas
+++ b/source/Img32.SVG.Core.pas
@@ -1848,7 +1848,7 @@ var
   i: integer;
 begin
   for i := 0 to attribs.Count -1 do
-    DisposeSvgAttrib(PSvgAttrib(attribs[i]));
+    DisposeSvgAttrib(PSvgAttrib(attribs.List[i]));
   attribs.Clear;
 
   for i := 0 to childs.Count -1 do
@@ -2313,11 +2313,10 @@ var
 begin
   //there are usually so few, that there seems little point sorting etc.
   for i := 0 to docType.attribs.Count -1 do
-    if PSvgAttrib(docType.attribs[i]).hash = hash then
-    begin
-      Result := PSvgAttrib(docType.attribs[i]);
-      Exit;
-    end;
+  begin
+    Result := PSvgAttrib(docType.attribs.List[i]);
+    if Result.hash = hash then Exit;
+  end;
   Result := nil;
 end;
 //------------------------------------------------------------------------------

--- a/source/Img32.SVG.Core.pas
+++ b/source/Img32.SVG.Core.pas
@@ -1444,16 +1444,15 @@ begin
     //get one or more class names for each pending style
     c2 := c;
     ParseNameLength(c, endC);
-    ToUTF8String(c2, c, aclassName);
+    ToAsciiLowerUTF8String(c2, c, aclassName);
 
-    AddName(Lowercase(String(aclassName)));
+    AddName(String(aclassName));
     if PeekNextChar(c, endC) = ',' then
     begin
       inc(c);
       Continue;
     end;
     if len = 0 then break;
-    SetLength(names, len); //ie no more comma separated names
 
     //now get the style
     if PeekNextChar(c, endC) <> '{' then Break;
@@ -1465,11 +1464,11 @@ begin
     if aStyle <> '' then
     begin
       //finally, for each class name add (or append) this style
-      for i := 0 to High(names) do
+      for i := 0 to len - 1 do
         stylesList.AddAppendStyle(names[i], aStyle);
     end;
-    names := nil;
-    len := 0; cap := 0;
+    // Reset the used names array length, so we can reuse it to reduce the amount of SetLength calls
+    len := 0;
     inc(c);
   end;
 end;
@@ -2311,10 +2310,11 @@ function TClassStylesList.GetStyle(const classname: UTF8String): UTF8String;
 var
   i: integer;
 begin
-  SetLength(Result, 0);
   i := fList.IndexOf(string(className));
   if i >= 0 then
-    Result := PAnsStringiRec(fList.objects[i]).ansi;
+    Result := PAnsStringiRec(fList.objects[i]).ansi
+  else
+    Result := '';
 end;
 //------------------------------------------------------------------------------
 

--- a/source/Img32.SVG.Path.pas
+++ b/source/Img32.SVG.Path.pas
@@ -1370,12 +1370,12 @@ begin
     SetLength(fSegs, fSegsCount);
 end;
 //------------------------------------------------------------------------------
+
 procedure TSvgSubPath.InitSegs(Capacity: Integer);
 begin
   if Capacity > fSegsCount then
     SetLength(fSegs, Capacity);
 end;
-
 //------------------------------------------------------------------------------
 
 function TSvgSubPath.GetCount: integer;

--- a/source/Img32.SVG.Path.pas
+++ b/source/Img32.SVG.Path.pas
@@ -343,11 +343,23 @@ end;
 
 function GetSingleDigit(var c, endC: PUTF8Char;
   out digit: integer): Boolean;
+var
+  cc: PUTF8Char;
+  ch: UTF8Char;
 begin
-  Result := SkipBlanksAndComma(c, endC) and (c^ >= '0') and (c^ <= '9');
+  cc := SkipBlanksAndComma(c, endC);
+  Result := cc < endC;
+  if not Result then
+  begin
+    c := cc;
+    Exit;
+  end;
+
+  ch := cc^;
+  Result := (ch >= '0') and (ch <= '9');
   if not Result then Exit;
-  digit := Ord(c^) - Ord('0');
-  inc(c);
+  digit := Ord(ch) - Ord('0');
+  c := cc + 1;
 end;
 //------------------------------------------------------------------------------
 

--- a/source/Img32.SVG.Path.pas
+++ b/source/Img32.SVG.Path.pas
@@ -199,10 +199,15 @@ type
     fSegs         : array of TSvgPathSeg;
     fPendingScale : double;
     fPathOffset   : TPointD;
+    fSegsCount    : integer;
     function GetCount: integer;
     function GetSeg(index: integer): TSvgPathSeg;
     function AddSeg(segType: TSvgPathSegType;
       const startPt: TPointD; const pts: TPathD): TSvgPathSeg;
+  protected
+    procedure GrowSegs;
+    procedure SegsLoaded;
+    procedure InitSegs(Capacity: Integer);
   public
     isClosed  : Boolean;
     constructor Create(parent: TSvgPath);
@@ -257,7 +262,7 @@ type
     procedure ScaleAndOffset(scale: double; dx, dy: integer);
     function  GetStringDef(relative: Boolean; decimalPrec: integer): string;
 
-    function AddPath: TSvgSubPath;
+    function AddPath(SegsCapacity: Integer = 0): TSvgSubPath;
     procedure DeleteSubPath(subPath: TSvgSubPath);
     property Bounds: TRectD read GetBounds;
     property CtrlBounds: TRectD read GetControlBounds;
@@ -1128,8 +1133,8 @@ begin
     fPendingScale := pendingScale;
 
   Result := nil;
-  SetLength(flattenedPaths, Length(fSegs));
-  for i := 0 to High(fSegs) do
+  SetLength(flattenedPaths, fSegsCount);
+  for i := 0 to fSegsCount - 1 do
     flattenedPaths[i] := fSegs[i].GetFlattened;
   ConcatPaths(Result, flattenedPaths);
 end;
@@ -1140,8 +1145,11 @@ function TSvgSubPath.AddSeg(segType: TSvgPathSegType;
 var
   i: integer;
 begin
-  i := Length(fSegs);
-  SetLength(fSegs, i+1);
+  i := fSegsCount;
+  if i = Length(fSegs) then
+    GrowSegs;
+  inc(fSegsCount);
+
   case segType of
     stCBezier    : Result := TSvgCSegment.Create(self, i, startPt);
     stHorz    : Result := TSvgHSegment.Create(self, i, startPt);
@@ -1165,8 +1173,11 @@ function TSvgSubPath.AddASeg(const startPt, endPt: TPointD; const rect: TRectD;
 var
   i: integer;
 begin
-  i := Length(fSegs);
-  SetLength(fSegs, i+1);
+  i := fSegsCount;
+  if i = Length(fSegs) then
+    GrowSegs;
+  inc(fSegsCount);
+
   Result := TSvgASegment.Create(self, i, startPt);
   fSegs[i] := Result;
   Result.pendingScale := self.fPendingScale;
@@ -1228,8 +1239,11 @@ function TSvgSubPath.AddZSeg(const endPt, firstPt: TPointD): TSvgZSegment;
 var
   i: integer;
 begin
-  i := Length(fSegs);
-  SetLength(fSegs, i+1);
+  i := fSegsCount;
+  if i = Length(fSegs) then
+    GrowSegs;
+  inc(fSegsCount);
+
   Result := TSvgZSegment.Create(self, i, endPt);
   fSegs[i] := Result;
   NewPointDArray(Result.fCtrlPts, 1, True);
@@ -1258,6 +1272,7 @@ begin
   if not Result then Exit;
   seg[cnt -1].Free;
   SetLength(fSegs, cnt -1);
+  fSegsCount := cnt - 1;
   if isClosed then isClosed := false;
 end;
 //------------------------------------------------------------------------------
@@ -1267,17 +1282,17 @@ var
   i: integer;
   paths: TPathsD;
 begin
-  if Length(fSegs) <= 1 then
+  if fSegsCount <= 1 then
   begin
     Result := Img32.Vector.MakePath(GetFirstPt);
-    for i := 0 to High(fSegs) do
+    for i := 0 to fSegsCount - 1 do
       ConcatPaths(Result, fSegs[i].GetOnPathCtrlPts);
   end
   else
   begin
-    SetLength(paths, 1 + Length(fSegs));
+    SetLength(paths, 1 + fSegsCount);
     paths[0] := Img32.Vector.MakePath(GetFirstPt);
-    for i := 0 to High(fSegs) do
+    for i := 0 to fSegsCount - 1 do
       paths[1 + i] := fSegs[i].GetOnPathCtrlPts;
     ConcatPaths(Result, paths);
   end;
@@ -1289,7 +1304,7 @@ var
   pt: TPointD;
 begin
   Result := '';
-  if Length(fSegs) = 0 then Exit;
+  if fSegsCount = 0 then Exit;
 
   if decimalPrec < -3 then decimalPrec := -3
   else if decimalPrec > 4 then decimalPrec := 4;
@@ -1337,13 +1352,35 @@ begin
   for i := 0 to Count -1 do
     fSegs[i].Free;
   fSegs := nil;
+  fSegsCount := 0;
   fPathOffset := NullPointD;
 end;
 //------------------------------------------------------------------------------
 
+procedure TSvgSubPath.GrowSegs;
+begin
+  SetLength(fSegs, (fSegsCount * 2) + 1);
+end;
+//------------------------------------------------------------------------------
+
+procedure TSvgSubPath.SegsLoaded;
+begin
+  // Trim the array to the actual used size
+  if Length(fSegs) <> fSegsCount then
+    SetLength(fSegs, fSegsCount);
+end;
+//------------------------------------------------------------------------------
+procedure TSvgSubPath.InitSegs(Capacity: Integer);
+begin
+  if Capacity > fSegsCount then
+    SetLength(fSegs, Capacity);
+end;
+
+//------------------------------------------------------------------------------
+
 function TSvgSubPath.GetCount: integer;
 begin
-  Result := Length(fSegs);
+  Result := fSegsCount;
 end;
 //------------------------------------------------------------------------------
 
@@ -1351,7 +1388,7 @@ procedure TSvgSubPath.Offset(dx, dy: double);
 var
   i: integer;
 begin
-  for i := 0 to High(fSegs) do fSegs[i].Offset(dx, dy);
+  for i := 0 to fSegsCount - 1 do fSegs[i].Offset(dx, dy);
 end;
 //------------------------------------------------------------------------------
 
@@ -1414,7 +1451,7 @@ begin
     with fSubPaths[i] do
     begin
       if scale <> 1 then
-      for j := 0 to High(fSegs) do
+      for j := 0 to fSegsCount - 1 do
         fSegs[j].Scale(scale);
       Offset(dx,dy);
     end;
@@ -1461,9 +1498,72 @@ var
     inc(ptCnt);
   end;
 
+  procedure AllocEstimatedPtsCount(c, endC: PUTF8Char);
+  begin
+    // Count the numbers before the next segment type char
+    ptCap := 0;
+    while c < endC do
+    begin
+      // skip whitespaces
+      while (c < endC) and (c^ <= space) do
+        inc(c);
+
+      if c >= endC then
+        break;
+
+      case c^ of
+        '0'..'9', '-', '.', 'E', 'e':
+          begin
+            while (c < endC) and (c^ > space) do
+              inc(c);
+            Inc(ptCap);
+          end;
+      else
+        Break;
+      end;
+    end;
+    ptCap := ptCap div 2; // two numbers are one point
+    SetLength(pts, ptCap);
+  end;
+
+  function EstimateSegs(c, endC: PUTF8Char): Integer;
+  var
+    ch: UTF8Char;
+  begin
+    Result := 0;
+    while True do
+    begin
+      if c >= endC then
+        Break;
+      ch := c^;
+      inc(c);
+
+      case ch of
+        'A'..'Z', 'a'..'z':
+          begin
+            case ch of
+              'M', 'm': // move / close
+                Break;
+              'Z', 'z':
+                begin
+                  Inc(Result);
+                  Break;
+                end;
+              'E', 'e': ; // Exponent of a number
+            else
+              Inc(Result);
+            end;
+          end;
+      end;
+    end;
+  end;
+
+var
+  ExpectedSegCount: Integer;
 begin
   Clear;
   currSubPath := nil;
+  ExpectedSegCount := 1;
 
   c := PUTF8Char(value);
   endC := c + Length(value);
@@ -1477,7 +1577,11 @@ begin
 
     if currSegType = stMove then
     begin
+      if currSubPath <> nil then
+        currSubPath.SegsLoaded; // Trim the segs array to the actual count
       currSubPath := nil;
+
+      ExpectedSegCount := EstimateSegs(c, endc);
 
       if isRelative then
         lastPt := currPt else
@@ -1489,6 +1593,7 @@ begin
       if IsNumPending(c, endC, true) then
         currSegType := stLine else
         Continue;
+      Inc(ExpectedSegCount);
     end
     else if (currSegType = stClose) then
     begin
@@ -1502,15 +1607,17 @@ begin
       end else
       begin
         if not Assigned(currSubPath) then
-          currSubPath := AddPath;
+          currSubPath := AddPath(1);
         currSubPath.AddZSeg(currPt, currPt);
       end;
+      currSubPath.SegsLoaded; // Trim the segs array to the actual count
       currSubPath := nil;
+      ExpectedSegCount := 1;
       Continue;
     end;
 
     if not Assigned(currSubPath) then
-      currSubPath := AddPath;
+      currSubPath := AddPath(ExpectedSegCount);
 
     pts := nil;
     ptCnt := 0; ptCap := 0;
@@ -1545,6 +1652,7 @@ begin
         end;
       stCBezier:
         begin
+          AllocEstimatedPtsCount(c, endC);
           while IsNumPending(c, endC, true) and
             Parse2Num(c, endC, pt2, lastPt) and
             Parse2Num(c, endC, pt3, lastPt) and
@@ -1555,22 +1663,26 @@ begin
             AddPt(currPt);
             if isRelative then lastPt := currPt;
           end;
-          SetLength(pts, ptCnt);
+          if Length(pts) <> ptCnt then
+            SetLength(pts, ptCnt);
           currSubPath.AddSeg(stCBezier, firstPt, pts);
         end;
       stHorz:
         begin
+          AllocEstimatedPtsCount(c, endC);
           while IsNumPending(c, endC, true) and
             Parse1Num(c, endC, currPt.X, lastPt.X) do
           begin
             AddPt(currPt);
             if isRelative then lastPt.X := currPt.X;
           end;
-          SetLength(pts, ptCnt);
+          if Length(pts) <> ptCnt then
+            SetLength(pts, ptCnt);
           currSubPath.AddHSeg(firstPt, pts);
         end;
       stQBezier, stCSpline:
         begin
+          AllocEstimatedPtsCount(c, endC);
           while IsNumPending(c, endC, true) and
             Parse2Num(c, endC, pt2, lastPt) and
             Parse2Num(c, endC, currPt, lastPt) do
@@ -1579,33 +1691,40 @@ begin
             AddPt(currPt);
             if isRelative then lastPt := currPt;
           end;
-          SetLength(pts, ptCnt);
+          if Length(pts) <> ptCnt then
+            SetLength(pts, ptCnt);
           currSubPath.AddSeg(currSegType, firstPt, pts);
         end;
       stLine, stQSpline:
         begin
+          AllocEstimatedPtsCount(c, endC);
           while IsNumPending(c, endC, true) and
             Parse2Num(c, endC, currPt, lastPt) do
           begin
             AddPt(currPt);
             if isRelative then lastPt := currPt;
           end;
-          SetLength(pts, ptCnt);
+          if Length(pts) <> ptCnt then
+            SetLength(pts, ptCnt);
           currSubPath.AddSeg(currSegType, firstPt, pts);
         end;
       stVert:
         begin
+          AllocEstimatedPtsCount(c, endC);
           while IsNumPending(c, endC, true) and
             Parse1Num(c, endC, currPt.Y, lastPt.Y) do
           begin
             AddPt(currPt);
             if isRelative then lastPt.Y := currPt.Y;
           end;
-          SetLength(pts, ptCnt);
+          if Length(pts) <> ptCnt then
+            SetLength(pts, ptCnt);
           currSubPath.AddVSeg(firstPt, pts);
         end;
     end;
   end;
+  if currSubPath <> nil then
+    currSubPath.SegsLoaded; // Trim the segs array to the actual count
 end;
 //------------------------------------------------------------------------------
 
@@ -1656,7 +1775,7 @@ begin
     with fSubPaths[i] do
     begin
       AppendPoint(p, GetFirstPt);
-      for j := 0 to High(fSegs) do
+      for j := 0 to fSegsCount - 1 do
         ConcatPaths(p, fSegs[j].fCtrlPts);
     end;
   Result := GetBoundsD(p);
@@ -1678,12 +1797,13 @@ begin
 end;
 //------------------------------------------------------------------------------
 
-function TSvgPath.AddPath: TSvgSubPath;
+function TSvgPath.AddPath(SegsCapacity: Integer): TSvgSubPath;
 var
   i: integer;
 begin
   i := Count;
   Result := TSvgSubPath.Create(self);
+  Result.InitSegs(SegsCapacity);
   SetLength(fSubPaths, i + 1);
   fSubPaths[i] := Result;
 end;

--- a/source/Img32.SVG.Reader.pas
+++ b/source/Img32.SVG.Reader.pas
@@ -76,7 +76,7 @@ type
 {$ENDIF}
     fId             : UTF8String;
     fDrawData       : TDrawData;    //currently both static and dynamic vars
-    function  FindRefElement(refname: UTF8String): TBaseElement;
+    function  FindRefElement(const refname: UTF8String): TBaseElement;
     function GetChildCount: integer;
     function GetChild(index: integer): TBaseElement;
     function FindChild(const idName: UTF8String): TBaseElement;
@@ -3774,7 +3774,7 @@ begin
 end;
 //------------------------------------------------------------------------------
 
-function TBaseElement.FindRefElement(refname: UTF8String): TBaseElement;
+function TBaseElement.FindRefElement(const refname: UTF8String): TBaseElement;
 var
   i, len: integer;
   c, endC: PUTF8Char;

--- a/source/Img32.SVG.Reader.pas
+++ b/source/Img32.SVG.Reader.pas
@@ -3791,7 +3791,7 @@ begin
     dec(endC); //removes trailing ')'
   end;
   if c^ = '#' then inc(c);
-  ref := ToUTF8String(c, endC);
+  ToUTF8String(c, endC, ref);
   i := fReader.fIdList.IndexOf(string(ref));
   if i >= 0 then
     Result := TBaseElement(fReader.fIdList.Objects[i]) else

--- a/source/Img32.SVG.Reader.pas
+++ b/source/Img32.SVG.Reader.pas
@@ -3854,14 +3854,14 @@ procedure BaselineShift_Attrib(aOwnerEl: TBaseElement; const value: UTF8String);
 var
   mu: TUnitType;
   val: double;
-  word: UTF8String;
+  hash: cardinal;
   c, endC: PUTF8Char;
 begin
   c := PUTF8Char(value);
   endC := c + Length(value);
-  ParseNextWord(c, endC, word);
+  ParseNextWordHash(c, endC, hash);
   with aOwnerEl.fDrawData.FontInfo do
-    case GetHash(word) of
+    case hash of
       hSuper: baseShift.SetValue(50, utPercent);
       hSub: baseShift.SetValue(-50, utPercent);
       hBaseline: baseShift.SetValue(0, utPixel);
@@ -3996,7 +3996,7 @@ end;
 
 procedure FontFamily_Attrib(aOwnerEl: TBaseElement; const value: UTF8String);
 var
-  word: UTF8String;
+  hash: cardinal;
   c, endC: PUTF8Char;
 begin
   with aOwnerEl.fDrawData.FontInfo do
@@ -4004,9 +4004,9 @@ begin
     family := ttfUnknown;
     c := PUTF8Char(value);
     endC := c + Length(value);
-    while ParseNextWordEx(c, endC, word) do
+    while ParseNextWordExHash(c, endC, hash) do
     begin
-      case GetHash(word) of
+      case hash of
         hSans_045_Serif, hArial  : family := ttfSansSerif;
         hSerif, hTimes: family := ttfSerif;
         hMonospace: family := ttfMonospace;
@@ -4039,10 +4039,9 @@ end;
 //------------------------------------------------------------------------------
 
 procedure FontWeight_Attrib(aOwnerEl: TBaseElement; const value: UTF8String);
-
 var
   num: double;
-  word: UTF8String;
+  hash: cardinal;
   c, endC: PUTF8Char;
 begin
   c := PUTF8Char(value);
@@ -4052,8 +4051,8 @@ begin
     if IsNumPending(c, endC, false) and
       ParseNextNum(c, endC, false, num) then
         weight := Round(num)
-    else if ParseNextWord(c, endC, word) then
-      case GetHash(word) of
+    else if ParseNextWordHash(c, endC, hash) then
+      case hash of
         hBold   : weight := 600;
         hNormal : weight := 400;
         hBolder : if weight >= 0 then weight := Min(900, weight + 200)
@@ -4242,14 +4241,14 @@ end;
 
 procedure StrokeLineCap_Attrib(aOwnerEl: TBaseElement; const value: UTF8String);
 var
-  word: UTF8String;
+  hash: cardinal;
   c, endC: PUTF8Char;
 begin
   c := PUTF8Char(value);
   endC := c + Length(value);
-  ParseNextWord(c, endC, word);
+  ParseNextWordHash(c, endC, hash);
   with aOwnerEl.fDrawData do
-    case GetHash(word) of
+    case hash of
       hButt   : strokeCap := esButt;
       hRound  : strokeCap := esRound;
       hSquare : strokeCap := esSquare;
@@ -4259,14 +4258,14 @@ end;
 
 procedure StrokeLineJoin_Attrib(aOwnerEl: TBaseElement; const value: UTF8String);
 var
-  word: UTF8String;
+  hash: cardinal;
   c, endC: PUTF8Char;
 begin
   c := PUTF8Char(value);
   endC := c + Length(value);
-  ParseNextWord(c, endC, word);
+  ParseNextWordHash(c, endC, hash);
   with aOwnerEl.fDrawData do
-    case GetHash(word) of
+    case hash of
       hMiter  : strokeJoin := jsMiter;
       hRound  : strokeJoin := jsRound;
       hBevel  : strokeJoin := jsSquare;
@@ -4557,15 +4556,15 @@ end;
 
 procedure SpreadMethod_Attrib(aOwnerEl: TBaseElement; const value: UTF8String);
 var
-  word: UTF8String;
+  hash: cardinal;
   c, endC: PUTF8Char;
 begin
   if not (aOwnerEl is TGradientElement) then Exit;
   c := PUTF8Char(value);
   endC := c + Length(value);
-  ParseNextWord(c, endC, word);
+  ParseNextWordHash(c, endC, hash);
   with TGradientElement(aOwnerEl) do
-    case GetHash(word) of
+    case hash of
       hPad      : spreadMethod := gfsClamp;
       hReflect  : spreadMethod := gfsMirror;
       hRepeat   : spreadMethod := gfsRepeat;

--- a/source/Img32.SVG.Reader.pas
+++ b/source/Img32.SVG.Reader.pas
@@ -3859,7 +3859,7 @@ var
 begin
   c := PUTF8Char(value);
   endC := c + Length(value);
-  ParseNextWordHash(c, endC, hash);
+  hash := ParseNextWordHash(c, endC);
   with aOwnerEl.fDrawData.FontInfo do
     case hash of
       hSuper: baseShift.SetValue(50, utPercent);
@@ -4246,7 +4246,7 @@ var
 begin
   c := PUTF8Char(value);
   endC := c + Length(value);
-  ParseNextWordHash(c, endC, hash);
+  hash := ParseNextWordHash(c, endC);
   with aOwnerEl.fDrawData do
     case hash of
       hButt   : strokeCap := esButt;
@@ -4263,7 +4263,7 @@ var
 begin
   c := PUTF8Char(value);
   endC := c + Length(value);
-  ParseNextWordHash(c, endC, hash);
+  hash := ParseNextWordHash(c, endC);
   with aOwnerEl.fDrawData do
     case hash of
       hMiter  : strokeJoin := jsMiter;
@@ -4562,7 +4562,7 @@ begin
   if not (aOwnerEl is TGradientElement) then Exit;
   c := PUTF8Char(value);
   endC := c + Length(value);
-  ParseNextWordHash(c, endC, hash);
+  hash := ParseNextWordHash(c, endC);
   with TGradientElement(aOwnerEl) do
     case hash of
       hPad      : spreadMethod := gfsClamp;

--- a/source/Img32.Text.pas
+++ b/source/Img32.Text.pas
@@ -671,11 +671,26 @@ end;
 
 function MergePathsArray(const pa: TArrayOfPathsD): TPathsD;
 var
-  i: integer;
+  i, j: integer;
+  resultCount: integer;
 begin
   Result := nil;
+
+  // Preallocate the Result-Array
+  resultCount := 0;
   for i := 0 to High(pa) do
-    AppendPath(Result, pa[i]);
+    inc(resultCount, Length(pa[i]));
+  SetLength(Result, resultCount);
+
+  resultCount := 0;
+  for i := 0 to High(pa) do
+  begin
+    for j := 0 to High(pa[i]) do
+    begin
+      Result[resultCount] := pa[i][j];
+      inc(resultCount);
+    end;
+  end;
 end;
 //------------------------------------------------------------------------------
 //------------------------------------------------------------------------------
@@ -2493,32 +2508,48 @@ end;
 function TFontCache.GetTextOutline(x, y: double; const text: UnicodeString;
   out nextX: double; underlineIdx: integer): TPathsD;
 var
-  i: integer;
+  i, j: integer;
   w, y2: double;
-  p: TPathD;
   arrayOfGlyphs: TArrayOfPathsD;
+  resultCount: integer;
 begin
   Result := nil;
   if not GetTextOutlineInternal(x, y, text,
     arrayOfGlyphs, nextX, underlineIdx) then Exit;
 
+  // pre allocate the Result array
+  resultCount := 0;
+  if fUnderlined then inc(resultCount);
+  for i := 0 to high(arrayOfGlyphs) do
+    inc(resultCount, Length(arrayOfGlyphs[i]));
+  if fStrikeOut then inc(resultCount);
+  SetLength(Result, resultCount);
+
+  resultCount := 0;
+
   if fUnderlined then
   begin
     w := LineHeight * lineFrac;
     y2 := y + 1.5 *(1+w);
-    p := Rectangle(x, y2, nextX, y2 + w);
-    AppendPath(Result, p);
+    Result[resultCount] := Rectangle(x, y2, nextX, y2 + w);
+    inc(resultCount);
   end;
 
   for i := 0 to high(arrayOfGlyphs) do
-    AppendPath(Result, arrayOfGlyphs[i]);
+  begin
+    for j := 0 to high(arrayOfGlyphs[i]) do
+    begin
+      Result[resultCount] := arrayOfGlyphs[i][j];
+      inc(resultCount);
+    end;
+  end;
 
   if fStrikeOut then
   begin
     w := LineHeight * lineFrac;
     y := y - LineHeight/4;
-    p := Rectangle(x, y , nextX, y + w);
-    AppendPath(Result, p);
+    Result[resultCount] := Rectangle(x, y , nextX, y + w);
+    //inc(ResultCount);
   end;
 end;
 //------------------------------------------------------------------------------

--- a/source/Img32.Vector.pas
+++ b/source/Img32.Vector.pas
@@ -71,7 +71,8 @@ type
 
   function NormalizeRect(var rect: TRect): Boolean;
 
-  function PrePendPoint(const pt: TPointD; const p: TPathD): TPathD;
+  function PrePendPoint(const pt: TPointD; const p: TPathD): TPathD; overload;
+  procedure PrePendPoint(const pt: TPointD; const p: TPathD; var Result: TPathD); overload;
   function PrePendPoints(const pt1, pt2: TPointD; const p: TPathD): TPathD;
 
   function Rectangle(const rec: TRect): TPathD; overload;
@@ -3641,14 +3642,20 @@ begin
 end;
 //------------------------------------------------------------------------------
 
-function PrePendPoint(const pt: TPointD; const p: TPathD): TPathD;
+procedure PrePendPoint(const pt: TPointD; const p: TPathD; var Result: TPathD);
 var
   len: integer;
 begin
   len := Length(p);
-  NewPointDArray(Result, len +1, True);
+  SetLengthUninit(Result, len +1);
   Result[0] := pt;
   if len > 0 then Move(p[0], Result[1], len * SizeOf(TPointD));
+end;
+//------------------------------------------------------------------------------
+
+function PrePendPoint(const pt: TPointD; const p: TPathD): TPathD;
+begin
+  PrePendPoint(pt, p, Result);
 end;
 //------------------------------------------------------------------------------
 
@@ -3779,7 +3786,7 @@ end;
 function FlattenCBezier(const firstPt: TPointD; const pts: TPathD;
   tolerance: double = 0.0): TPathD; overload;
 begin
-    Result := FlattenCBezier(PrePendPoint(firstPt, pts), tolerance);
+  Result := FlattenCBezier(PrePendPoint(firstPt, pts), tolerance);
 end;
 //------------------------------------------------------------------------------
 

--- a/source/Img32.Vector.pas
+++ b/source/Img32.Vector.pas
@@ -2864,9 +2864,12 @@ begin
     end;
   end
   else
+  begin
+    SetLength(Result, Length(lines));
     for i := 0 to high(lines) do
-      AppendPath(Result, GrowOpenLine(lines[i], lineWidth,
-        joinStyle, endStyle, miterLimOrRndScale));
+      Result[i] := GrowOpenLine(lines[i], lineWidth,
+        joinStyle, endStyle, miterLimOrRndScale);
+  end;
 end;
 //------------------------------------------------------------------------------
 

--- a/source/Img32.Vector.pas
+++ b/source/Img32.Vector.pas
@@ -3573,35 +3573,76 @@ end;
 function GetBoundsD(const paths: TPathsD): TRectD;
 var
   i,j: integer;
-  l,t,r,b: double;
   p: PPointD;
+  {$IFDEF CPUX64}
+  l,t,r,b,x,y: double;
+  {$ENDIF CPUX64}
 begin
-  l := MaxDouble; t := MaxDouble;
-  r := -MaxDouble; b := -MaxDouble;
+  if paths = nil then
+  begin
+    Result := NullRectD;
+    Exit;
+  end;
+
+  {$IFDEF CPUX64}
+  l := MaxDouble; t := l;
+  r := -MaxDouble; b := r;
+  {$ELSE}
+  Result.Left := MaxDouble;
+  Result.Top := MaxDouble;
+  Result.Right := -MaxDouble;
+  Result.Bottom := -MaxDouble;
+  {$ENDIF CPUX64}
   for i := 0 to high(paths) do
   begin
     p := PPointD(paths[i]);
     if not assigned(p) then Continue;
     for j := 0 to high(paths[i]) do
     begin
-      if p.x < l then l := p.x;
-      if p.x > r then r := p.x;
-      if p.y < t then t := p.y;
-      if p.y > b then b := p.y;
+      {$IFDEF CPUX64}
+      // load p.X and p.Y into xmm registers
+      x := p.X;
+      y := p.Y;
+      if x < l then l := x;
+      if x > r then r := x;
+      if y < t then t := y;
+      if y > b then b := y;
+      {$ELSE}
+      // If we must use the FPU and memory then we should write directly
+      // to the target memory.
+      if p.x < Result.Left   then Result.Left := p.x;
+      if p.x > Result.Right  then Result.Right := p.x;
+      if p.y < Result.Top    then Result.Top := p.y;
+      if p.y > Result.Bottom then Result.Bottom := p.y;
+      {$ENDIF CPUX64}
       inc(p);
     end;
   end;
+  {$IFDEF CPUX64}
   if r < l then
-    result := NullRectD else
-    result := RectD(l, t, r, b);
+    Result := NullRectD
+  else
+  begin
+    // Inline the RectD() call by hand
+    Result.Left := l;
+    Result.Top := t;
+    Result.Right := r;
+    Result.Bottom := b;
+  end;
+  {$ELSE}
+  if Result.Right < Result.Left then
+    Result := NullRectD;
+  {$ENDIF CPUX64}
 end;
 //------------------------------------------------------------------------------
 
 function GetBoundsD(const path: TPathD): TRectD;
 var
   i,highI: integer;
-  l,t,r,b: double;
   p: PPointD;
+  {$IFDEF CPUX64}
+  l,t,r,b,x,y: double;
+  {$ENDIF CPUX64}
 begin
   highI := High(path);
   if highI < 0 then
@@ -3609,18 +3650,49 @@ begin
     Result := NullRectD;
     Exit;
   end;
+
+  {$IFDEF CPUX64}
   l := path[0].X; r := l;
   t := path[0].Y; b := t;
   p := PPointD(path);
   for i := 1 to highI do
   begin
     inc(p);
-    if p.x < l then l := p.x;
-    if p.x > r then r := p.x;
-    if p.y < t then t := p.y;
-    if p.y > b then b := p.y;
+    // load p.X and p.Y into xmm registers
+    x := p.X;
+    y := p.Y;
+    if x < l then l := x;
+    if x > r then r := x;
+    if y < t then t := y;
+    if y > b then b := y;
   end;
-  result := RectD(l, t, r, b);
+  // Inline the RectD() call by hand
+  Result.Left := l;
+  Result.Top := t;
+  Result.Right := r;
+  Result.Bottom := b;
+  {$ELSE}
+  // If we must use the FPU and memory then we should write directly
+  // to the target memory.
+    {$IFDEF RECORD_METHODS}
+  Result.TopLeft := path[0]; // uses "rep movsd"
+  Result.BottomRight := Result.TopLeft;
+    {$ELSE}
+  Result.Left := path[0].X; // uses "fld" and "fstp"
+  Result.Top := path[0].Y;
+  Result.Right := Result.Left;
+  Result.Bottom := Result.Right;
+    {$ENDIF RECORD_METHODS}
+  p := PPointD(path);
+  for i := 1 to highI do
+  begin
+    inc(p);
+    if p.x < Result.Left   then Result.Left := p.x;
+    if p.x > Result.Right  then Result.Right := p.x;
+    if p.y < Result.Top    then Result.Top := p.y;
+    if p.y > Result.Bottom then Result.Bottom := p.y;
+  end;
+  {$ENDIF CPUX64}
 end;
 //------------------------------------------------------------------------------
 
@@ -3700,7 +3772,7 @@ begin
   highI := high(pts);
   if highI < 0 then Exit;
   if (highI < 2) or Odd(highI) then
-    raise Exception.Create(rsInvalidQBezier);
+    raise Exception.CreateRes(@rsInvalidQBezier);
   if tolerance <= 0.0 then tolerance := BezierTolerance;
   NewPointDArray(Result, 1, True);
   Result[0] := pts[0];

--- a/source/Img32.inc
+++ b/source/Img32.inc
@@ -42,6 +42,7 @@
   {$DEFINE PBYTE}
   {$DEFINE NEWPOSFUNC}
   {$DEFINE SUPPORTS_POINTERMATH}
+  {$DEFINE CLASS_STATIC}
   {.$DEFINE UITYPES}
   {$DEFINE NESTED_TYPES}
   {$IFNDEF DEBUG}
@@ -79,6 +80,7 @@
           {$DEFINE EXIT_PARAM}                    //added Exit(value)
           {$DEFINE ALPHAFORMAT}                   //added TBitmap.AlphaFormat property
           {$DEFINE SUPPORTS_POINTERMATH}          //added {$POINTERMATH ON/OFF}
+          {$DEFINE CLASS_STATIC}                  //added class static methods
           {$IF COMPILERVERSION >= 21}           //Delphi 2010
             {$DEFINE GESTURES}                    //added screen gesture support
             {$IF COMPILERVERSION >= 23}         //DelphiXE2

--- a/source/Img32.pas
+++ b/source/Img32.pas
@@ -732,7 +732,7 @@ end;
 function InternSetSimpleDynArrayLengthUninit(a: Pointer; count: nativeint; elemSize: integer): Pointer;
 var
   p: PDynArrayRec;
-  oldCount: integer;
+  oldCount: nativeint;
 begin
   if a = nil then
     Result := NewSimpleDynArray(count, elemSize)
@@ -761,7 +761,8 @@ begin
       // SetLength makes a copy of the dyn array to get RefCnt=1
       GetMem(Pointer(p), SizeOf(TDynArrayRec) + count * elemSize);
       if oldCount < 0 then oldCount := 0; // data corruption detected
-      Move(a^, p.Data, Min(oldCount, count) * elemSize);
+      if oldCount > count then oldCount := count;
+      Move(a^, p.Data, oldCount * elemSize);
       TArrayOfByte(a) := nil; // use a non-managed dyn.array type
     end;
 


### PR DESCRIPTION
This PR improves the performance of the SVG parser.
It is very large PR that I've started almost 3 months ago.

**Optimizations:**
- Fixing the leaking `{$OVERFLOWCHECKS ON}` in Img32.SVG.Core.pas improves the speed of the code that comes below the leaks.
- All `New(PSvgAttrib(attrib))` are replaced by an inlined helper function, that doesn't rely on the slow RTTI. Also the `Dispose(PSvgAttrib(attrib))` is replaced by a helper function that skips the RTTI code and clears the two UTF8String itself.
- A lot of `element in Set` operators are replaced by `case element of` that Delphi's Win64 compiler can optimize whereas it lacks the ability to optimize the in-operator.
- Many string parsing functions don't use a var-parameter for the PUTF8Char anymore because that forced the iterator variable to be stored and loaded from memory every time the code accesses it. Especially loops were affected by this.
- Code that resized dynamic arrays now calculates the final number of elements before calling `SetLength`
- Numbers in SVG files are parsed with multiple data type stages: Integer->Int64->Double. So "smaller" numbers can be parsed much faster.
- `TColorConstList` and `TClassStylesList` are now HashMaps with UTF8Strings instead of UnicodeStrings that had to be cast forth and back.
- `GetHash` got an overload that accepts a PUTF8Char and a len-parameter. If `ToUTF8String` was only used to call `GetHash`, then we can now skip the UTF8String creation and call `GetHash` directly on the input PUTF8Char.
- `GetBoundsD` is now CPU register optimized for 32bit and for 64bit
- By using `TList.List[]` instead of `TList.Items[]` the code now skips the Lists's index check in for-loop that iterate over the whole list.


This PR also fixes the Delphi 2007 compilation. Delphi 2007 seems to have an function overload resolver bug. It tries to call `Math.Min(Extended, Extended)` for two `NativeInt` parameters.