### PR TITLE
Wrong color in example SVG spider.svg

### DIFF
--- a/source/Img32.SVG.Reader.pas
+++ b/source/Img32.SVG.Reader.pas
@@ -2539,7 +2539,8 @@ begin
   end
   else if drawDat.fillColor = clInvalid then
   begin
-    DrawPolygon(img, fillPaths, drawDat.fillRule, clBlack32,
+    DrawPolygon(img, fillPaths, drawDat.fillRule,
+      MergeColorAndOpacity(clBlack32, drawDat.fillOpacity),
       fReader.fCustomRendererCache);
   end
   else


### PR DESCRIPTION
This PR fixes the wrong color for the "Sucking stomach" in the SVG example spider.svg. It was painted black instead of ochre yellow, because the PATH doesn't have a fill-color. This leads to painting it black. But the PATH has a fill-opacity that was ignored. This patch merges the back color with the fill-opacity.