### PR TITLE
Replace TSvgReader.IdList with a HashMap

### DIFF
--- a/source/Img32.SVG.Core.pas
+++ b/source/Img32.SVG.Core.pas
@@ -243,6 +243,7 @@ type
   procedure ToUTF8String(c, endC: PUTF8Char; var S: UTF8String);
   procedure ToAsciiLowerUTF8String(c, endC: PUTF8Char; var S: UTF8String);
   procedure ToTrimmedUTF8String(c, endC: PUTF8Char; var S: UTF8String);
+  function IsSameUTF8String(const S1, S2: UTF8String): Boolean;
 
   //special parsing functions //////////////////////////////////////////
   procedure ParseStyleElementContent(const value: UTF8String; stylesList: TClassStylesList);
@@ -2680,11 +2681,13 @@ begin
   end;
 end;
 //------------------------------------------------------------------------------
+
 procedure TClassStylesList.Preallocate(AdditionalItemCount: Integer);
 begin
   if AdditionalItemCount > 2 then
     Grow(Length(FItems) + AdditionalItemCount);
 end;
+//------------------------------------------------------------------------------
 
 function TClassStylesList.FindItemIndex(Hash: Cardinal; const Name: UTF8String): Integer;
 begin


### PR DESCRIPTION
This PR replaces the `IdList: TStringList` with a specialized HashMap that also removes the need to convert UTF8String to UnicodeString for every FindRefElement call.
