### PR TITLE
Improve (Fast)Gaussian performance

### DIFF
--- a/source/Img32.Transform.pas
+++ b/source/Img32.Transform.pas
@@ -106,7 +106,7 @@ type
   public
     procedure Reset; overload; {$IFDEF INLINE} inline; {$ENDIF}
     procedure Reset(c: TColor32; w: Integer = 1); overload; {$IFDEF INLINE} inline; {$ENDIF}
-    procedure Add(c: TColor32; w: Integer); overload;
+    procedure Add(c: TColor32; w: Integer); overload; {$IFDEF INLINE} inline; {$ENDIF}
     procedure Add(c: TColor32); overload; {$IFDEF INLINE} inline; {$ENDIF}
     procedure Add(const other: TWeightedColor); overload;
       {$IFDEF INLINE} inline; {$ENDIF}
@@ -1136,12 +1136,25 @@ end;
 //------------------------------------------------------------------------------
 
 procedure TWeightedColor.Reset;
+{$IFDEF CPUX64}
+var
+  Zero: Int64;
+{$ENDIF CPUX64}
 begin
+  {$IFDEF CPUX64}
+  Zero := 0;
+  fAddCount := Zero;
+  fAlphaTot := Zero;
+  fColorTotR := Zero;
+  fColorTotG := Zero;
+  fColorTotB := Zero;
+  {$ELSE}
   fAddCount := 0;
   fAlphaTot := 0;
   fColorTotR := 0;
   fColorTotG := 0;
   fColorTotB := 0;
+  {$ENDIF CPUX64}
 end;
 //------------------------------------------------------------------------------
 
@@ -1178,12 +1191,15 @@ var
   a: Cardinal;
 begin
   inc(fAddCount, w);
-  a := w * Byte(c shr 24);
-  if a = 0 then Exit;
-  inc(fAlphaTot, a);
-  inc(fColorTotB, (a * Byte(c)));
-  inc(fColorTotG, (a * Byte(c shr 8)));
-  inc(fColorTotR, (a * Byte(c shr 16)));
+  a := Byte(c shr 24);
+  if (a <> 0) and (w <> 0) then
+  begin
+    a := Integer(a) * w;
+    inc(fAlphaTot, a);
+    inc(fColorTotB, (a * Byte(c)));
+    inc(fColorTotG, (a * Byte(c shr 8)));
+    inc(fColorTotR, (a * Byte(c shr 16)));
+  end;
 end;
 //------------------------------------------------------------------------------
 

--- a/source/Img32.Transform.pas
+++ b/source/Img32.Transform.pas
@@ -106,7 +106,15 @@ type
   public
     procedure Reset; overload; {$IFDEF INLINE} inline; {$ENDIF}
     procedure Reset(c: TColor32; w: Integer = 1); overload; {$IFDEF INLINE} inline; {$ENDIF}
-    procedure Add(c: TColor32; w: Integer); overload; {$IFDEF INLINE} inline; {$ENDIF}
+    procedure Add(c: TColor32; w: Integer); overload;
+      {$IFDEF FPC}
+        {$IFDEF INLINE} inline; {$ENDIF}
+      {$ELSE}
+        // Delphi 2006-2009 bug with INLINE ("incompatible type")
+        {$IF CompilerVersion > 20.0}
+          {$IFDEF INLINE} inline; {$ENDIF}
+        {$IFEND}
+      {$ENDIF}
     procedure Add(c: TColor32); overload; {$IFDEF INLINE} inline; {$ENDIF}
     procedure Add(const other: TWeightedColor); overload;
       {$IFDEF INLINE} inline; {$ENDIF}
@@ -1192,9 +1200,9 @@ var
 begin
   inc(fAddCount, w);
   a := Byte(c shr 24);
-  if (a <> 0) and (w <> 0) then
+  if a <> 0 then
   begin
-    a := Integer(a) * w;
+    a := a * Cardinal(w);
     inc(fAlphaTot, a);
     inc(fColorTotB, (a * Byte(c)));
     inc(fColorTotG, (a * Byte(c shr 8)));


### PR DESCRIPTION
This PR improves the performance of the FastGaussianBlur and GaussianBlur functions.

- Removing `lastColor := src[re]` leads to a much better CPU register allocation in BoxBlurH/V
- "const" instead of "var" for the BoxBlurH/V dyn-array parameters removes a memory indirection every time `src[]` and `dst[]` are accessed
- GaussianBlur: Calculate all colors before accessing them multiple times
- GaussianBlur: Help the Delphi 64 bit compiler with TWeightedColor.Reset
