### PR TITLE
Additional grayscale algorithms and optimzations

### DIFF
--- a/source/Img32.SVG.Core.pas
+++ b/source/Img32.SVG.Core.pas
@@ -1630,10 +1630,10 @@ begin
     if ParseNextChar(c, endC) <> ')' then Exit;
     for i := 0 to 3 do if IsFraction(vals[i]) then
       vals[i] := vals[i] * 255;
-    color := ClampByte(Round(vals[3])) shl 24 +
-      ClampByte(Round(vals[0])) shl 16 +
-      ClampByte(Round(vals[1])) shl 8 +
-      ClampByte(Round(vals[2]));
+    color := ClampByte(Integer(Round(vals[3]))) shl 24 +
+      ClampByte(Integer(Round(vals[0]))) shl 16 +
+      ClampByte(Integer(Round(vals[1]))) shl 8 +
+      ClampByte(Integer(Round(vals[2])));
   end
   else if (c^ = '#') then           //#RRGGBB or #RGB
   begin

--- a/source/Img32.SVG.Reader.pas
+++ b/source/Img32.SVG.Reader.pas
@@ -2136,7 +2136,7 @@ var
 begin
   if not GetSrcAndDst or not Assigned(values) then Exit;
   for i := 0 to 19 do
-    colorMatrix[i] := ClampByte(Round(values[i]*255));
+    colorMatrix[i] := ClampByte(Integer(Round(values[i]*255)));
 
   dx1 := srcImg.Width - RectWidth(srcRec);
   dx2 := dstImg.Width - RectWidth(dstRec);

--- a/source/Img32.pas
+++ b/source/Img32.pas
@@ -1944,7 +1944,7 @@ begin
   c := ((255 - abs(2 * hsl.lum - 255)) * hsl.sat) shr 8;
   a := 252 - (hsl.hue mod 85) * 6;
   x := (c * (255 - abs(a))) shr 8;
-  m := hsl.lum - c div 2;
+  m := hsl.lum - c shr 1{div 2}; // Delphi's 64bit compiler can't optimize this
   rgba.A := hsl.alpha;
   case (hsl.hue * 6) shr 8 of
     0: begin rgba.R := c + m; rgba.G := x + m; rgba.B := 0 + m; end;
@@ -4019,7 +4019,7 @@ begin
   pb := PARGB(PixelBase);
   for i := 0 to Width * Height - 1 do
   begin
-    pb.A := ClampByte(Round(pb.A * scale));
+    pb.A := ClampByte(Integer(Round(pb.A * scale)));
     inc(pb);
   end;
   Changed;

--- a/source/Img32.pas
+++ b/source/Img32.pas
@@ -28,9 +28,6 @@ uses
   {$IFDEF UITYPES} UITypes,{$ENDIF} Math;
 
 type
-  {$IF not declared(NativeInt)}
-  NativeInt = Integer;
-  {$IFEND}
   {$IF not declared(SizeInt)} // FPC has SizeInt
     {$IF CompilerVersion < 120}
   SizeInt = Integer; // Delphi 7-2007 can't use NativeInt with "FOR"


### PR DESCRIPTION
This PR adds two additional grayscale algorithms and optimizes some color operations.

### Grayscale
The default `TImage32.Grayscale` algorithm changes the saturation of the image, but that is not what SVG gray-scaling does (WebBrowsers, Skia). They use an algorithm that uses the perceptive contrast to generate the gray scale image.

This patch doesn't change the default behavior of the `Grayscale` method, but adds two parameters to it. The first sets the algorithm (Saturation, Linear, Colorimetric) and the second defines the merge amount [0.0-1.0]. The amount parameter doesn't have any effect if "Saturation" is used.

I thought about changing the default to "Linear", which is also faster than "Saturation". That would help SVG images. But if someone already uses it for non-SVG things, it would change the behavior.

### Performance optimizations
The functions `InvertColors` and `InvertAlphas` use PStaticColor32Array instead of incrementing the pointer.

The `AdjustHue`, `AdjustLuminance` and `AdjustSaturation` functions only calculate the new color if the original color is different from the previous color, giving them a huge speed up for larger same color blocks or fully transparent parts in an image.

### ClampByte(Round(...))
`ClampByte` has two overloads. One for `Integer` and one for `Double`. The (Delphi) compiler always calls the Double-overload if you call `ClampByte` with the result of `Round`. This happens because `Round` returns an Int64 and that doesn't fit into an Integer, thus `ClampByte(Integer)` can't be used and the next "best" overload is the Double-overload.

So we get "Double->Int64->Double->Int64->Byte" instead of "Double->Integer->Byte".
To prevent this, all the code that uses `ClampByte(Round(...))` is replaced with `ClampByte(Integer(Round(...)))`.

An Int64-overload for `ClampByte` would have been also possible, but the 32bit compiler would become slower, as it would have to push the Int64 onto the stack instead of using a CPU register for the `ClampByte` parameter.

### Cleanup
The `$IF not declared(NativeInt)` isn't necessary. All compilers that are supported (Delphi 7+ and FPC) have that datatype. The only problem with Delphi 7-2007 is that NativeInt can't be used with FOR-loops. So this PR also introduces the `SizeInt` Datatype for Delphi, that FPC already has. It is an "Integer" for Delphi 7-2007 and a "NativeInt" for all newer Delphi versions, so it can be used with FOR-loops.