### PR TITLE
Work around a compiler INLINE bug

### DIFF
--- a/source/Img32.Transform.pas
+++ b/source/Img32.Transform.pas
@@ -106,15 +106,7 @@ type
   public
     procedure Reset; overload; {$IFDEF INLINE} inline; {$ENDIF}
     procedure Reset(c: TColor32; w: Integer = 1); overload; {$IFDEF INLINE} inline; {$ENDIF}
-    procedure Add(c: TColor32; w: Integer); overload;
-      {$IFDEF FPC}
-        {$IFDEF INLINE} inline; {$ENDIF}
-      {$ELSE}
-        // Delphi 2006-2009 bug with INLINE ("incompatible type")
-        {$IF CompilerVersion > 20.0}
-          {$IFDEF INLINE} inline; {$ENDIF}
-        {$IFEND}
-      {$ENDIF}
+    procedure Add(c: TColor32; w: Integer); overload; {$IFDEF INLINE_COMPATIBLE} inline; {$ENDIF}
     procedure Add(c: TColor32); overload; {$IFDEF INLINE} inline; {$ENDIF}
     procedure Add(const other: TWeightedColor); overload;
       {$IFDEF INLINE} inline; {$ENDIF}
@@ -122,8 +114,8 @@ type
     procedure Subtract(c: TColor32); overload; {$IFDEF INLINE} inline; {$ENDIF}
     procedure Subtract(const other: TWeightedColor); overload;
       {$IFDEF INLINE} inline; {$ENDIF}
-    function AddSubtract(addC, subC: TColor32): Boolean; {$IFDEF INLINE} inline; {$ENDIF}
-    function AddNoneSubtract(c: TColor32): Boolean; {$IFDEF INLINE} inline; {$ENDIF}
+    function AddSubtract(addC, subC: TColor32): Boolean; {$IFDEF INLINE_COMPATIBLE} inline; {$ENDIF}
+    function AddNoneSubtract(c: TColor32): Boolean; {$IFDEF INLINE_COMPATIBLE} inline; {$ENDIF}
     procedure AddWeight(w: Integer); {$IFDEF INLINE} inline; {$ENDIF}
     property AddCount: Integer read fAddCount;
     property Color: TColor32 read GetColor;

--- a/source/Img32.inc
+++ b/source/Img32.inc
@@ -47,6 +47,7 @@
   {$DEFINE NESTED_TYPES}
   {$IFNDEF DEBUG}
     {$DEFINE INLINE}
+    {$DEFINE INLINE_COMPATIBLE}
   {$ENDIF}
   {$DEFINE DELPHI_PNG}
   {$IFDEF WINDOWS}
@@ -82,6 +83,9 @@
           {$DEFINE SUPPORTS_POINTERMATH}          //added {$POINTERMATH ON/OFF}
           {$DEFINE CLASS_STATIC}                  //added class static methods
           {$IF COMPILERVERSION >= 21}           //Delphi 2010
+            {$IFNDEF DEBUG}
+              {$DEFINE INLINE_COMPATIBLE}         //avoid compiler bug with INLINE in Delphi 2005-2009 ("incompatible type")
+            {$ENDIF}
             {$DEFINE GESTURES}                    //added screen gesture support
             {$IF COMPILERVERSION >= 23}         //DelphiXE2
               {$DEFINE USES_NAMESPACES}


### PR DESCRIPTION
The Delphi 2005-2009 compilers have problems with some inlined methods and fail with bogus "incompatible type" errors for the parameters.

This pull request introduces the new compiler condition "INLINE_COMPATIBLE" in img32.inc that is only defined for FPC and Delphi >= 2010. This allows to easily "remove" the `inline` from methods for those Delphi versions that cause problems.

Instead of
```Delphi
function MyProc(value: TColor32); {$IFDEF INLINE} inline; {$ENDIF}
```
The function header will like like
Instead of
```Delphi
function MyProc(value: TColor32); {$IFDEF INLINE_COMPATIBLE} inline; {$ENDIF}
```