### PR TITLE
Fix some smaller bugs

### DIFF
--- a/source/Img32.Text.pas
+++ b/source/Img32.Text.pas
@@ -1137,7 +1137,7 @@ var
   hdl: HFont;
 begin
   Result := false;
-  hdl := CreateFontIndirect(logfont);
+  hdl := CreateFontIndirect(@logfont);
   if hdl > 0 then
   try
     Result := LoadUsingFontHdl(hdl);
@@ -3940,7 +3940,7 @@ begin
 end;
 //------------------------------------------------------------------------------
 
-function FontSorterProc(const fontreader1, fontreader2: Pointer): integer;
+function FontSorterProc(fontreader1, fontreader2: Pointer): integer;
 var
   fr1: TFontReader absolute fontreader1;
   fr2: TFontReader absolute fontreader2;


### PR DESCRIPTION
This PR fixes some smaller bugs and makes some (really) minor optimization.

Fixes:
- The `SizeInt` data type was always `Integer`, because the `CompilerVersion` was compared to 120, which is the Delphi 2009 package version. But it should have been the compiler version 20.0.
- `BlendBlueChannel` used the red channel instead of the blue channel. For SVG images this didn't make a difference, because it is only used for mask images (all 3 colors have the same value).

Optimizations:
- `BlendBlueChannelLine` uses the "negative array index" trick for a better CPU register usage.
- `CopyBlendInternal` uses `const` on the `srcRec` parameter, saving save stack operations.