### PR TITLE
Fix issue #125: ClipPath ignores transformations in the clipPath itself

### DIFF
--- a/source/Img32.SVG.Reader.pas
+++ b/source/Img32.SVG.Reader.pas
@@ -2493,7 +2493,11 @@ begin
         GetPaths(drawDat);
         AppendPath(self.drawPathsO, drawPathsO);
         AppendPath(self.drawPathsC, drawPathsC);
+        MatrixApply(DrawData.matrix, self.drawPathsC);
+        MatrixApply(DrawData.matrix, self.drawPathsO);
       end;
+  MatrixApply(DrawData.matrix, drawPathsC);
+  MatrixApply(DrawData.matrix, drawPathsO);
   drawPathsF := CopyPaths(drawPathsC);
   AppendPath(drawPathsF, drawPathsO);
 end;


### PR DESCRIPTION
This PR fixes issue #125 by calling ApplyMatrix for every clip-path element that has a "transform" attribute and the clip-path itsself if it has a "transform" attribute.