### PR TITLE
Fix possible memory overwrite due to missing bounds check

### DIFF
--- a/source/Img32.Text.pas
+++ b/source/Img32.Text.pas
@@ -2972,7 +2972,7 @@ var
   dc: HDC;
 begin
   Result := nil;
-  if faceName = '' then Exit;
+  if (faceName = '') or (Length(faceName) > LF_FACESIZE) then Exit;
   FillChar(lf, sizeof(lf), 0);
   lf.lfCharSet := charSet;
   Move(faceName[1], lf.lfFaceName[0], Length(faceName) * SizeOf(Char));


### PR DESCRIPTION
This patch fixes a possible memory overwrite if the `GetLogFonts` function is called with a `FaceName` that is larger than the `TLogFont.lfFaceName` array.