### PR TITLE
Skip the use of the tmpImage in TShapeElement.Draw if possible.

### DIFF
--- a/source/Img32.Vector.pas
+++ b/source/Img32.Vector.pas
@@ -267,6 +267,7 @@ type
   function Rect(const left,top,right,bottom: integer): TRect; overload;
 
   function PtInRect(const rec: TRectD; const pt: TPointD): Boolean; overload;
+  function RectInRect(const rec1, rec2: TRectD): Boolean;
 
   function Size(cx, cy: integer): TSize;
   function SizeD(cx, cy: double): TSizeD;
@@ -280,7 +281,8 @@ type
 
   function Area(const path: TPathD): Double; overload;
 
-  function RectsEqual(const rec1, rec2: TRect): Boolean;
+  function RectsEqual(const rec1, rec2: TRect): Boolean; overload;
+  function RectsEqual(const rec1, rec2: TRectD): Boolean; overload;
 
   procedure TranslateRect(var rec: TRect; dx, dy: integer); overload;
   procedure TranslateRect(var rec: TRectD; dx, dy: double); overload;
@@ -600,6 +602,13 @@ begin
 end;
 //------------------------------------------------------------------------------
 
+function RectsEqual(const rec1, rec2: TRectD): Boolean;
+begin
+  result := (rec1.Left = rec2.Left) and (rec1.Top = rec2.Top) and
+    (rec1.Right = rec2.Right) and (rec1.Bottom = rec2.Bottom);
+end;
+//------------------------------------------------------------------------------
+
 function Rect(const left, top, right, bottom: integer): TRect;
 begin
   Result.Left := left;
@@ -775,6 +784,15 @@ function PtInRect(const rec: TRectD; const pt: TPointD): Boolean;
 begin
   Result := (pt.X >= rec.Left) and (pt.X < rec.Right) and
     (pt.Y >= rec.Top) and (pt.Y < rec.Bottom);
+end;
+//------------------------------------------------------------------------------
+
+function RectInRect(const rec1, rec2: TRectD): Boolean;
+var
+  r: TRectD;
+begin
+  r := UnionRect(rec1, rec2);
+  Result := RectsEqual(rec1, r) or RectsEqual(rec2, r);
 end;
 //------------------------------------------------------------------------------
 


### PR DESCRIPTION
This patch improves the drawing performance.

If the ShapeElement has a clip-element that is a rectangle and there are no other masks or filters and all paths are completely in the clip-region, it is possible to directly draw the shape into the target image instead of painting into a temporary image and then blending that into the target image. That improves the performance a lot, if a SVG image contains many of such clip elements (e.g. Koppen-Geiger_Map_Cfc_present.svg).