### PR TITLE
Very small micro-optimizations

### DIFF
--- a/source/Img32.Draw.pas
+++ b/source/Img32.Draw.pas
@@ -1100,8 +1100,8 @@ begin
     // EvenOdd
     lastValue := Trunc(Abs(accum) * 1275) mod 2550; // mul 5
     if lastValue > 1275 then
-      lastValue := (2550 - lastValue) shr 2 else    // div 4
-      lastValue := lastValue shr 2;                 // div 4
+      lastValue := 2550 - lastValue;
+    lastValue := lastValue shr 2;                   // div 4
     if lastValue > 255 then lastValue := 255;
 
     buf[count] := Byte(lastValue);

--- a/source/Img32.pas
+++ b/source/Img32.pas
@@ -2177,8 +2177,8 @@ end;
 
 function TRectD.MidPoint: TPointD;
 begin
-  Result.X := (Right + Left) / 2;
-  Result.Y := (Bottom + Top) / 2;
+  Result.X := (Right + Left) * 0.5;
+  Result.Y := (Bottom + Top) * 0.5;
 end;
 //------------------------------------------------------------------------------
 
@@ -4472,7 +4472,7 @@ begin
       MulTable[i, j] := Round(i * j * div255);
       if i >= j then
         DivTable[i, j] := 255 else
-        DivTable[i, j] := Round(i * $FF / j);
+        DivTable[i, j] := Round(i * 255 / j);
     end;
   end;
 


### PR DESCRIPTION
This PR makes two little micro-optimizations.

- Remove unnecessary unconditional jump in FillByteBufferEvenOdd() by removing "else".
- Replace division by 2 with a multiplication by 0.5 in TRectD.MidPoint()