### PR TITLE
Fix compile errors in Delphi 7, 2007, 2009 and XE

### DIFF
--- a/source/Img32.Text.pas
+++ b/source/Img32.Text.pas
@@ -897,7 +897,7 @@ begin
 end;
 //------------------------------------------------------------------------------
 
-function SameText(const text1, text2: Utf8String): Boolean; overload;
+function SameUtf8Text(const text1, text2: Utf8String): Boolean;
 var
   len: integer;
 begin
@@ -3276,7 +3276,7 @@ begin
   for Result := 0 to fFontList.Count -1 do
   begin
     fi2 := TFontReader(fFontList[Result]).FontInfo;
-    if SameText(fi.fullFaceName, fi2.fullFaceName) and
+    if SameUtf8Text(fi.fullFaceName, fi2.fullFaceName) and
       (fi.macStyles = fi2.macStyles) then Exit;
     end;
   Result := -1;
@@ -3512,7 +3512,7 @@ function TFontManager.GetBestMatchFont(const fontInfo: TFontInfo): TFontReader;
     // third priority (shl 3)
     if name1 = '' then
       Result := 0 else
-    if SameText(name1, name2) then Result := 0 else Result := 4;
+    if SameUtf8Text(name1, name2) then Result := 0 else Result := 4;
   end;
 
   function GetFullNameDiff(const fiToMatch: TFontInfo;
@@ -3525,9 +3525,9 @@ function TFontManager.GetBestMatchFont(const fontInfo: TFontInfo): TFontReader;
     if Assigned(fiToMatch.familyNames) then
     begin
       for i := 0 to High(fiToMatch.familyNames) do
-        if SameText(fiToMatch.familyNames[i], candidateName) then Exit;
+        if SameUtf8Text(fiToMatch.familyNames[i], candidateName) then Exit;
     end
-    else if SameText(fiToMatch.faceName, candidateName) then Exit;
+    else if SameUtf8Text(fiToMatch.faceName, candidateName) then Exit;
     Result := 2;
   end;
 

--- a/source/Img32.TextChunks.pas
+++ b/source/Img32.TextChunks.pas
@@ -284,7 +284,14 @@ end;
 
 function TTextChunk.IsText: Boolean;
 begin
-  Result := not CharInSet(text[1], [SPACE, NEWLINE]);
+  // CharInSet is slow in Win32 and generates even slower code for Win64
+  //Result := not CharInSet(text[1], [SPACE, NEWLINE]);
+  case text[1] of
+    SPACE, NEWLINE:
+      Result := False;
+  else
+    Result := True;
+  end;
 end;
 //------------------------------------------------------------------------------
 
@@ -568,12 +575,12 @@ begin
   for i := startIdx to endIdx do
     TTextChunk(fList.Items[i]).Free;
 
-{$IFDEF FPC}
+{$IF defined(FPC) or not defined(LIST_DELETERANGE)}
   for i := endIdx-startIdx +1 downto startIdx do
     fList.Delete(i);
 {$ELSE}
   fList.DeleteRange(startIdx, endIdx-startIdx +1);
-{$ENDIF}
+{$IFEND}
 
   // reindex
   for i := startIdx to fList.Count -1 do

--- a/source/Img32.inc
+++ b/source/Img32.inc
@@ -99,7 +99,8 @@
             {$IF COMPILERVERSION >= 23}         //DelphiXE2
               {$DEFINE USES_NAMESPACES}
               {$DEFINE FORMATSETTINGS}
-              {$DEFINE TROUNDINGMODE}   
+              {$DEFINE TROUNDINGMODE}
+              {$DEFINE LIST_DELETERANGE}          //added TList.DeleteRange
               {$DEFINE UITYPES}                   //added UITypes unit
               {$DEFINE XPLAT_GENERICS}            //cross-platform generics support
               {$DEFINE STYLESERVICES}             //added StyleServices unit


### PR DESCRIPTION
This PR fixes the compiler errors for Delphi 7 to XE.

- CharInSet doesn't exist in Delphi 7 and 2007 (and is slow in all other versions)
- Renamed Img32.Text.pas::SameText to SameUtf8Text because 2007 fails with "SameText is ambiguous" error
- TList.DeleteRange was introduced in XE2. This patch adds a new DEFINE "LIST_DELETERANGE" that is defined for Delphi XE2 and newer