### PR TITLE
FlipHorizontal, FlipVertically, CenterPaths

### DIFF
--- a/source/Img32.SVG.Reader.pas
+++ b/source/Img32.SVG.Reader.pas
@@ -165,6 +165,9 @@ type
     fRootElement      : TSvgElement;
     fFontCache        : TFontCache;
     fKeepAspectRatio  : Boolean;
+    fFlipHorizontal   : Boolean;
+    fFlipVertical     : Boolean;
+
     function  LoadInternal: Boolean;
     function  GetIsEmpty: Boolean;
     function  GetTempImage: TImage32;
@@ -188,6 +191,9 @@ type
     function  LoadFromString(const str: string): Boolean;
     function  GetImageSize: TSize;
 
+    function GetPathBounds: TRectD;
+    function DrawFullPathsInCenter: Boolean;
+
     // The following two methods are deprecated and intended only for ...
     // https://github.com/EtheaDev/SVGIconImageList
     procedure SetOverrideFillColor(color: TColor32); //deprecated;
@@ -199,9 +205,10 @@ type
     property  IsEmpty         : Boolean read GetIsEmpty;
     // KeepAspectRatio: this property has also been added for the convenience of
     // the third-party SVGIconImageList. (IMHO it should always = true)
-    property  KeepAspectRatio: Boolean
-      read fKeepAspectRatio write fKeepAspectRatio;
+    property  KeepAspectRatio : Boolean read fKeepAspectRatio write fKeepAspectRatio;
     property  RootElement     : TSvgElement read fRootElement;
+    property  FlipHorizontal  : Boolean read fFlipHorizontal write fFlipHorizontal;
+    property  FlipVertical    : Boolean read fFlipVertical write fFlipVertical;
   end;
 
 var
@@ -5645,6 +5652,23 @@ begin
 end;
 //------------------------------------------------------------------------------
 
+function TSvgReader.DrawFullPathsInCenter: Boolean;
+var
+  LRectD: TRectD;
+begin
+  Result := false;
+  LRectD:= GetPathBounds;
+  if LRectD.IsEmpty then
+    Exit;
+
+  Self.RootElement.viewboxWH.Left := LRectD.Left;
+  Self.RootElement.viewboxWH.Top := LRectD.Top;
+  Self.RootElement.viewboxWH.Width := LRectD.Width;
+  Self.RootElement.viewboxWH.Height := LRectD.Height;
+  Result := true;
+end;
+//------------------------------------------------------------------------------
+
 procedure TSvgReader.DrawImage(img: TImage32; scaleToImage: Boolean);
 var
   scale, scaleH: double;
@@ -5668,6 +5692,25 @@ begin
       di.currentColor := currentColor;
 
     MatrixTranslate(di.matrix, -viewboxWH.Left, -viewboxWH.Top);
+
+    // flips done in *viewbox space* (unit = SVG units), not with -scale
+    if fFlipHorizontal and fFlipVertical then
+    begin
+      MatrixScale(di.matrix, -1, -1);
+      MatrixTranslate(di.matrix, viewboxWH.Width, viewboxWH.Height);
+    end else
+    if fFlipHorizontal then
+    begin
+      // mirror around vertical axis of viewbox
+      MatrixScale(di.matrix, -1, 1);
+      MatrixTranslate(di.matrix, viewboxWH.Width, 0);
+    end else
+    if fFlipVertical then
+    begin
+      // mirror around horizontal axis of viewbox
+      MatrixScale(di.matrix, 1, -1);
+      MatrixTranslate(di.matrix, 0, viewboxWH.Height);
+    end;
 
     //the width and height attributes generally indicate the size of the
     //rendered image unless they are percentage values. Nevertheless, these
@@ -5698,7 +5741,6 @@ begin
         Round(viewboxWH.Height * scaleH));
     end else
       img.SetSize(Round(viewboxWH.Width), Round(viewboxWH.Height));
-
   end;
 
   if fBkgndColor <> clNone32 then
@@ -5844,6 +5886,17 @@ function TSvgReader.GetIsEmpty: Boolean;
 begin
   Result := not Assigned(fRootElement);
 end;
+//------------------------------------------------------------------------------
+
+function TSvgReader.GetPathBounds: TRectD;
+begin
+  if not Assigned(Self.fRootElement) then begin
+    Result := NullRectD;
+    Exit;
+  end;
+  Result := Self.fRootElement.GetBounds;
+end;
+
 //------------------------------------------------------------------------------
 //------------------------------------------------------------------------------
 


### PR DESCRIPTION
Hello,
Recently, I've been trying to add some common features for SVG images.
I've added support for flipping in function DrawImage.
I've tried using the path bounds to set the viewbox rectangle, which allows all paths to be displayed within the SVG window, which may help resolve some viewbox issues. I've also made KeepAspectRatio configurable, with a default of true.

Hopefully, this feature will be added to the master branch.

For a demo, please have a look of the 
https://github.com/wqmeng/SVGIconImageList/tree/center_all_paths

The demo SvgViewer which shows the features of the VCL framework. And also the SVGIconImageList added FMX support for the above features too.

Thanks so much.