### PR TITLE
Fix font-size with unit type "em"

### DIFF
--- a/source/Img32.SVG.Core.pas
+++ b/source/Img32.SVG.Core.pas
@@ -3,7 +3,7 @@ unit Img32.SVG.Core;
 (*******************************************************************************
 * Author    :  Angus Johnson                                                   *
 * Version   :  4.9                                                             *
-* Date      :  9 August 2025                                                   *
+* Date      :  15 December 2025                                                *
 * Website   :  https://www.angusj.com                                          *
 * Copyright :  Angus Johnson 2019-2025                                         *
 *                                                                              *
@@ -103,6 +103,7 @@ type
     family        : TFontFamily;
     familyNames   : UTF8Strings;
     size          : double;
+    sizeUnitType  : TUnitType;
     spacing       : double;
     spacesInText  : TSpacesInText;
     textLength    : double;
@@ -1681,6 +1682,7 @@ procedure GetSvgFontInfo(const value: UTF8String; var fontInfo: TSVGFontInfo);
 var
   c, endC: PUTF8Char;
   hash: Cardinal;
+  tmp: TValue;
 begin
   c := PUTF8Char(value);
   endC := c + Length(value);
@@ -1689,7 +1691,12 @@ begin
     if c = ';' then
       break
     else if IsNumPending(c, endC, true) then
-      ParseNextNum(c, endC, true, fontInfo.size)
+    begin
+      tmp.Init;
+      if not ParseNextNumEx(c, endC, true, tmp.rawVal, tmp.unitType) then Exit;
+      fontInfo.size := tmp.rawVal;
+      fontInfo.sizeUnitType := tmp.unitType;
+    end
     else
     begin
       hash := ParseNextWordHashed(c, endC);

--- a/source/Img32.SVG.Reader.pas
+++ b/source/Img32.SVG.Reader.pas
@@ -794,6 +794,8 @@ end;
 //------------------------------------------------------------------------------
 
 procedure UpdateFontInfo(var drawDat: TDrawData; thisElement: TBaseElement);
+var
+  fontValue: TValue;
 begin
   with thisElement.fDrawData do
   begin
@@ -806,7 +808,12 @@ begin
       drawDat.fontInfo.familyNames := fontInfo.familyNames;
 
     if fontInfo.size > 0 then
-      drawDat.fontInfo.size := fontInfo.size;
+    begin
+      // Convert fontsize+unitType to pixels
+      fontValue.SetValue(fontInfo.size, fontInfo.sizeUnitType);
+      drawDat.fontInfo.size := fontValue.GetValue(drawDat.fontInfo.size, 1);
+      drawDat.fontInfo.sizeUnitType := utPixel;
+    end;
     if fontInfo.spacing <> 0 then
       drawDat.fontInfo.spacing := fontInfo.spacing;
     if fontInfo.textLength > 0 then
@@ -4672,12 +4679,14 @@ end;
 
 procedure FontSize_Attrib(aOwnerEl: TBaseElement; const value: UTF8String);
 var
-  num: double;
   c, endC: PUTF8Char;
+  tmp: TValue;
 begin
   c := PUTF8Char(value); endC := c + Length(value);
-  if not ParseNextNum(c, endC, false, num) then Exit;
-  aOwnerEl.fDrawData.FontInfo.size := num;
+  tmp.Init;
+  if not ParseNextNumEx(c, endC, false, tmp.rawVal, tmp.unitType) then Exit;
+  aOwnerEl.fDrawData.fontInfo.size := tmp.rawVal;
+  aOwnerEl.fDrawData.fontInfo.sizeUnitType := tmp.unitType;
 end;
 //------------------------------------------------------------------------------
 


### PR DESCRIPTION
The unit type "em" for the font-size was read as pixels instead of being a scale factor for the parent font-size. This PR keeps the raw font-size value and the unit type in the element.fDrawInfo.fontInfo record. The UpdateFontInfo() method converts it to pixels for the actual "drawDat".

Original SVG:
![TextSizeUnitEm](https://github.com/user-attachments/assets/cd93347c-77b9-40ac-a0a4-a07aff19b6fa)

Without the patch (png):
<img width="660" height="220" alt="TextSizeUnitEm" src="https://github.com/user-attachments/assets/121fffc1-fa83-48f1-bed9-e0a616e76a4c" />

With the patch (png):
<img width="660" height="220" alt="TextSizeUnitEm" src="https://github.com/user-attachments/assets/596866d9-fa14-4d11-8607-c3050042ba52" />