### PR TITLE
Img32.SVG.Reader - fixed a bug in TSvgReader.GetBestFont where the font-style was ignored

### DIFF
--- a/source/Img32.SVG.Reader.pas
+++ b/source/Img32.SVG.Reader.pas
@@ -5864,6 +5864,7 @@ var
   fi: TFontInfo;
 begin
   FillChar(fi, SizeOf(fi), 0);
+  fi.fontFormat := ffTrueType;
   if svgFontInfo.family <> tfUnknown then
     fi.family := svgFontInfo.family;
   fi.faceName := ''; //just match to a family here, not to a specific facename


### PR DESCRIPTION
This PR fixes a bug in `TSvgReader.GetBestFont` that caused all fonts to be painted as "normal" fonts instead of "bold" or "italic".

The formerly uninitialized local variable `fi: TFontInfo` in `TSvgReader.GetBestFont` had a random value, mostly a value other than `ffInvalid` (value: 0), in the `fi.fontFormat"` field. After adding the `FillChar` in commit 340642c643f7fbc554600fbd7157dba214204e27 the field is now always initialized to `ffInvalid`. This causes the `FontManager.GetBestMatchFont` to only compare the font-family and font-face but ignores the style (italic, bold, ...), so that bold and italic fonts a painted as "normal" fonts.

This patch sets `fr.fontFormat` always to `ttTrueType` in `TSvgReader.GetBestFont`.
